### PR TITLE
Restrict interface language choices to Russian and English

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/src/i18n/uiTexts.js
+++ b/src/i18n/uiTexts.js
@@ -7,7 +7,8 @@ export const uiTexts = {
     result: "Вы получили",
     resultPoints: "баллов",
     playAgain: "Играть снова",
-    instruction: "Выберите правильное название растения"
+    instruction: "Выберите правильное название растения",
+    interfaceLanguageLabel: "Язык интерфейса"
   },
   en: {
     question: "What plant is this?",
@@ -17,7 +18,8 @@ export const uiTexts = {
     result: "You scored",
     resultPoints: "points",
     playAgain: "Play Again",
-    instruction: "Choose the correct plant name"
+    instruction: "Choose the correct plant name",
+    interfaceLanguageLabel: "Interface language"
   },
   sci: {
     question: "Quae planta est?",
@@ -27,7 +29,8 @@ export const uiTexts = {
     result: "Score",
     resultPoints: "points",
     playAgain: "Ludere iterum",
-    instruction: "Choose the correct scientific name"
+    instruction: "Elige nomen scientificum rectum",
+    interfaceLanguageLabel: "Lingua interfaciei"
   }
 };
 


### PR DESCRIPTION
## Summary
- separate interface language from plant name language and persist both preferences
- display an interface language selector under the quiz and update UI text resources
- store language choices in localStorage and ignore node_modules in version control
- limit interface language selection to Russian and English, guarding persisted defaults from the Sci option

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6e60c7a94832eb288332b2db153ac