### PR TITLE
Add difficulty mappings for quiz questions

### DIFF
--- a/src/data/catalog.js
+++ b/src/data/catalog.js
@@ -1,3 +1,5 @@
+import { getDifficultyByQuestionId } from './difficulties.js';
+
 // ЕДИНЫЙ ИСТОЧНИК ДАННЫХ: все таксоны в одном месте.
 // У некоторых есть image => они могут быть вопросами; у остальных пока только варианты.
 export const speciesById = {
@@ -89,5 +91,6 @@ export const plants = Object.entries(speciesById)
     id: Number(id),
     image: v.image,
     names: v.names,
-    wrongAnswers: v.wrongAnswers
+    wrongAnswers: v.wrongAnswers,
+    difficulty: getDifficultyByQuestionId(Number(id))
   }));

--- a/src/data/difficulties.js
+++ b/src/data/difficulties.js
@@ -1,0 +1,24 @@
+export const difficultyLevels = Object.freeze({
+  EASY: 'Easy',
+  MEDIUM: 'Medium',
+  HARD: 'Hard'
+});
+
+export const questionIdsByDifficulty = Object.freeze({
+  [difficultyLevels.EASY]: Object.freeze([6, 31, 33, 35, 51, 55]),
+  [difficultyLevels.MEDIUM]: Object.freeze([2, 30, 3, 54, 4, 5]),
+  [difficultyLevels.HARD]: Object.freeze([1, 32, 34, 50, 53, 52])
+});
+
+const difficultyByQuestionId = Object.freeze(
+  Object.entries(questionIdsByDifficulty).reduce((acc, [difficulty, ids]) => {
+    ids.forEach(id => {
+      acc[id] = difficulty;
+    });
+    return acc;
+  }, {})
+);
+
+export function getDifficultyByQuestionId(questionId) {
+  return difficultyByQuestionId[questionId] || null;
+}


### PR DESCRIPTION
## Summary
- add a dedicated difficulty map that groups quiz question ids into Easy, Medium, and Hard buckets
- enrich the cataloged plant questions with a hidden difficulty flag sourced from the shared map

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7af3d5718832ebcafee844b736a8a