### PR TITLE
Implement multi-round gameplay flow

### DIFF
--- a/src/components/PlantQuizGame.js
+++ b/src/components/PlantQuizGame.js
@@ -1,6 +1,6 @@
-const { useState, useEffect, useRef, useCallback } = React;
+const { useState, useEffect, useCallback } = React;
 
-const QUESTIONS_PER_SESSION = 6;
+const QUESTIONS_PER_ROUND = 6;
 
 const AVAILABLE_LANGUAGES = ['ru', 'en', 'sci'];
 const INTERFACE_LANGUAGES = ['ru', 'en'];
@@ -28,6 +28,24 @@ function getStoredPlantLanguage() {
 import { plants, choicesById, ALL_CHOICE_IDS } from '../data/catalog.js';
 import { shuffleArray } from '../utils/random.js';
 import { uiTexts, defaultLang } from '../i18n/uiTexts.js';
+import { difficultyLevels } from '../data/difficulties.js';
+
+const ROUNDS = Object.freeze([
+  { id: 1, difficulty: difficultyLevels.EASY },
+  { id: 2, difficulty: difficultyLevels.MEDIUM },
+  { id: 3, difficulty: difficultyLevels.HARD }
+]);
+
+const TOTAL_ROUNDS = ROUNDS.length;
+
+function getQuestionsForRound(difficulty) {
+  const pool = plants.filter(plant => plant.difficulty === difficulty);
+  const roundLength = Math.min(QUESTIONS_PER_ROUND, pool.length);
+  if (roundLength === 0) {
+    return [];
+  }
+  return shuffleArray(pool).slice(0, roundLength);
+}
 
 export default function PlantQuizGame() {
   const [interfaceLanguage, setInterfaceLanguage] = useState(() => getStoredInterfaceLanguage() || defaultLang);
@@ -44,6 +62,8 @@ export default function PlantQuizGame() {
 
     return defaultLang;
   });
+  const [currentRoundIndex, setCurrentRoundIndex] = useState(0);
+  const [roundPhase, setRoundPhase] = useState('playing');
   const [sessionPlants, setSessionPlants] = useState([]);
   const [currentQuestion, setCurrentQuestion] = useState(0);
   const [score, setScore] = useState(0);
@@ -56,48 +76,39 @@ export default function PlantQuizGame() {
     }
     return false;
   });
-  const remainingDeckRef = useRef([]);
 
   const texts = uiTexts[interfaceLanguage] || uiTexts[defaultLang];
 
-  // Запуск новой игровой сессии
-  const startNewSession = useCallback((resetDeck = false) => {
-    const currentDeck = Array.isArray(remainingDeckRef.current)
-      ? remainingDeckRef.current
-      : [];
-    let workingDeck = currentDeck.slice();
-
-    if (resetDeck || workingDeck.length < QUESTIONS_PER_SESSION) {
-      const existingIds = new Set(workingDeck.map(plant => plant.id));
-      const replenished = shuffleArray(plants).filter(plant => !existingIds.has(plant.id));
-      workingDeck = [...workingDeck, ...replenished];
-
-      if (workingDeck.length < QUESTIONS_PER_SESSION) {
-        workingDeck = [...workingDeck, ...shuffleArray(plants)];
-      }
-    }
-
-    if (workingDeck.length === 0) {
-      setSessionPlants([]);
-      setCurrentQuestion(0);
-      setScore(0);
-      setGameState('playing');
-      setOptionIds([]);
-      setCorrectAnswerId(null);
+  // Запуск нового раунда
+  const startRound = useCallback((roundIndex, resetScore = false) => {
+    const roundConfig = ROUNDS[roundIndex];
+    if (!roundConfig) {
       return;
     }
 
-    const shuffledDeck = shuffleArray(workingDeck);
-    const sessionSelection = shuffledDeck.slice(0, QUESTIONS_PER_SESSION);
-    remainingDeckRef.current = shuffledDeck.slice(QUESTIONS_PER_SESSION);
+    const questions = getQuestionsForRound(roundConfig.difficulty);
+    setCurrentRoundIndex(roundIndex);
 
-    setSessionPlants(sessionSelection);
+    if (resetScore) {
+      setScore(0);
+    }
+
+    setSessionPlants(questions);
     setCurrentQuestion(0);
-    setScore(0);
     setGameState('playing');
     setOptionIds([]);
     setCorrectAnswerId(null);
-  }, [plants, shuffleArray]);
+
+    if (questions.length === 0) {
+      setRoundPhase(roundIndex >= TOTAL_ROUNDS - 1 ? 'gameComplete' : 'roundComplete');
+    } else {
+      setRoundPhase('playing');
+    }
+  }, []);
+
+  const startGame = useCallback(() => {
+    startRound(0, true);
+  }, [startRound]);
 
   // Генерация ID вариантов ответов для растения
   function generateOptionIds(plant) {
@@ -122,10 +133,10 @@ export default function PlantQuizGame() {
     return shuffleArray([correctId, ...wrongIds]);
   }
 
-  // Инициализация первой игровой сессии
+  // Инициализация игры
   useEffect(() => {
-    startNewSession(true);
-  }, [startNewSession]);
+    startGame();
+  }, [startGame]);
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -143,6 +154,10 @@ export default function PlantQuizGame() {
 
   // Генерация вариантов при смене вопроса
   useEffect(() => {
+    if (roundPhase !== 'playing') {
+      return;
+    }
+
     if (sessionPlants.length > 0 && currentQuestion < sessionPlants.length) {
       const currentPlant = sessionPlants[currentQuestion];
       if (gameState === 'playing' || currentQuestion === 0) {
@@ -151,7 +166,7 @@ export default function PlantQuizGame() {
         setCorrectAnswerId(currentPlant.id);
       }
     }
-  }, [currentQuestion, sessionPlants]);
+  }, [currentQuestion, sessionPlants, gameState, roundPhase]);
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -173,6 +188,10 @@ export default function PlantQuizGame() {
 
   // Обработка ответа
   function handleAnswer(selectedId) {
+    if (roundPhase !== 'playing' || gameState !== 'playing') {
+      return;
+    }
+
     if (selectedId === correctAnswerId) {
       setScore(prev => prev + 1);
       setGameState('correct');
@@ -180,12 +199,18 @@ export default function PlantQuizGame() {
       setGameState('incorrect');
     }
 
+    const isLastQuestion = currentQuestion + 1 >= sessionPlants.length;
+
     setTimeout(() => {
-      if (currentQuestion + 1 < sessionPlants.length) {
+      if (isLastQuestion) {
+        const isFinalRound = currentRoundIndex === TOTAL_ROUNDS - 1;
+        setRoundPhase(isFinalRound ? 'gameComplete' : 'roundComplete');
+        setGameState('playing');
+        setOptionIds([]);
+        setCorrectAnswerId(null);
+      } else {
         setCurrentQuestion(prev => prev + 1);
         setGameState('playing');
-      } else {
-        setGameState('finished');
       }
     }, 1500);
   }
@@ -202,6 +227,17 @@ export default function PlantQuizGame() {
     setInterfaceLanguage(newLang);
   }
 
+  function handleStartNextRound() {
+    const nextRoundIndex = currentRoundIndex + 1;
+    if (nextRoundIndex < TOTAL_ROUNDS) {
+      startRound(nextRoundIndex);
+    }
+  }
+
+  function handleRestart() {
+    startGame();
+  }
+
   // Получение изображения растения
   function getPlantImage(plantData) {
     if (plantData.image && plantData.image.startsWith('images/')) {
@@ -216,8 +252,50 @@ export default function PlantQuizGame() {
     return null;
   }
 
-  // Экран завершения
-  if (gameState === 'finished') {
+  // Экран завершения раунда
+  if (roundPhase === 'roundComplete') {
+    const roundNumber = currentRoundIndex + 1;
+    const nextRoundNumber = currentRoundIndex + 2;
+    const roundCompletedText = (texts.roundCompleted || '').replace('{{round}}', roundNumber);
+    const startNextRoundText = (texts.startRoundButton || '').replace('{{round}}', nextRoundNumber);
+
+    return React.createElement('div', {
+      className: 'min-h-screen flex items-center justify-center relative',
+      style: { backgroundColor: '#163B3A', padding: isMobile ? '3px' : '16px' }
+    }, [
+      !isMobile && React.createElement('div', { key: 'decor1', className: 'absolute top-4 left-4 w-20 h-1', style: { backgroundColor: '#C29C27' } }),
+      !isMobile && React.createElement('div', { key: 'decor2', className: 'absolute top-8 left-8 w-32 h-1', style: { backgroundColor: '#C29C27' } }),
+      !isMobile && React.createElement('div', { key: 'decor3', className: 'absolute bottom-4 right-4 w-20 h-1', style: { backgroundColor: '#C29C27' } }),
+      !isMobile && React.createElement('div', { key: 'decor4', className: 'absolute bottom-8 right-8 w-32 h-1', style: { backgroundColor: '#C29C27' } }),
+      React.createElement('div', {
+        key: 'round-result',
+        className: 'p-8 shadow-lg text-center max-w-md mx-4 flex flex-col gap-4',
+        style: { backgroundColor: '#163B3A', border: '6px solid #C29C27' }
+      }, [
+        React.createElement('h1', {
+          key: 'round-title',
+          className: 'text-3xl font-bold',
+          style: { color: '#C29C27' }
+        }, roundCompletedText || `Round ${roundNumber} completed!`),
+        React.createElement('p', {
+          key: 'round-score',
+          className: 'text-2xl font-semibold',
+          style: { color: '#C29C27' }
+        }, `${texts.score}: ${score}`),
+        React.createElement('button', {
+          key: 'next-round',
+          onClick: handleStartNextRound,
+          className: 'px-6 py-3 font-semibold text-white transition-colors hover:opacity-80',
+          style: { backgroundColor: '#163B3A', border: '4px solid #C29C27', color: '#C29C27' }
+        }, startNextRoundText || 'Start next round')
+      ])
+    ]);
+  }
+
+  // Экран завершения игры
+  if (roundPhase === 'gameComplete') {
+    const completedText = (texts.gameCompletedTitle || '').replace('{{score}}', score);
+
     return React.createElement('div', {
       className: 'min-h-screen flex items-center justify-center relative',
       style: { backgroundColor: '#163B3A', padding: isMobile ? '3px' : '16px' }
@@ -228,20 +306,20 @@ export default function PlantQuizGame() {
       !isMobile && React.createElement('div', { key: 'decor4', className: 'absolute bottom-8 right-8 w-32 h-1', style: { backgroundColor: '#C29C27' } }),
       React.createElement('div', {
         key: 'result',
-        className: 'p-8 shadow-lg text-center max-w-md mx-4',
+        className: 'p-8 shadow-lg text-center max-w-md mx-4 flex flex-col gap-4',
         style: { backgroundColor: '#163B3A', border: '6px solid #C29C27' }
       }, [
         React.createElement('h1', {
           key: 'title',
-          className: 'text-4xl font-bold mb-6',
+          className: 'text-3xl font-bold',
           style: { color: '#C29C27' }
-        }, `${texts.result} ${score} ${texts.resultPoints}!`),
+        }, completedText || `${texts.result} ${score} ${texts.resultPoints}!`),
         React.createElement('button', {
           key: 'restart',
-          onClick: () => startNewSession(),
+          onClick: handleRestart,
           className: 'px-6 py-3 font-semibold text-white transition-colors hover:opacity-80',
           style: { backgroundColor: '#163B3A', border: '4px solid #C29C27', color: '#C29C27' }
-        }, texts.playAgain)
+        }, texts.restart || texts.playAgain || 'Restart')
       ])
     ]);
   }
@@ -259,14 +337,23 @@ export default function PlantQuizGame() {
     !isMobile && React.createElement('div', { key: 'decor6', className: 'absolute bottom-12 right-12 w-16 h-1', style: { backgroundColor: '#C29C27' } }),
 
     React.createElement('div', { key: 'container', className: 'w-full max-w-5xl mx-auto relative z-10' }, [
-      React.createElement('div', { key: 'header', className: 'flex justify-between items-center mb-6' }, [
+      React.createElement('div', { key: 'header', className: 'flex justify-between items-center mb-6 flex-wrap gap-4' }, [
         React.createElement('div', {
-          key: 'progress',
-          className: 'text-2xl font-bold',
+          key: 'progress-info',
+          className: 'flex flex-col',
           style: { color: '#C29C27' }
-        }, sessionPlants.length > 0
-          ? `${currentQuestion + 1}/${sessionPlants.length}`
-          : `0/${QUESTIONS_PER_SESSION}`),
+        }, [
+          React.createElement('span', {
+            key: 'round-info',
+            className: 'text-lg font-semibold'
+          }, `${texts.roundLabel || 'Round'} ${currentRoundIndex + 1}/${TOTAL_ROUNDS}`),
+          React.createElement('span', {
+            key: 'progress',
+            className: 'text-2xl font-bold'
+          }, sessionPlants.length > 0
+            ? `${currentQuestion + 1}/${sessionPlants.length}`
+            : `0/${QUESTIONS_PER_ROUND}`)
+        ]),
 
         React.createElement('div', { key: 'right-section', className: 'flex items-center gap-4' }, [
           React.createElement('div', {

--- a/src/i18n/uiTexts.js
+++ b/src/i18n/uiTexts.js
@@ -8,7 +8,12 @@ export const uiTexts = {
     resultPoints: "баллов",
     playAgain: "Играть снова",
     instruction: "Выберите правильное название растения",
-    interfaceLanguageLabel: "Язык интерфейса"
+    interfaceLanguageLabel: "Язык интерфейса",
+    roundLabel: "Раунд",
+    roundCompleted: "Раунд {{round}} завершён!",
+    startRoundButton: "Начать Раунд {{round}}",
+    gameCompletedTitle: "Вы прошли игру! Ваши баллы: {{score}}",
+    restart: "Начать заново"
   },
   en: {
     question: "What plant is this?",
@@ -19,7 +24,12 @@ export const uiTexts = {
     resultPoints: "points",
     playAgain: "Play Again",
     instruction: "Choose the correct plant name",
-    interfaceLanguageLabel: "Interface language"
+    interfaceLanguageLabel: "Interface language",
+    roundLabel: "Round",
+    roundCompleted: "Round {{round}} completed!",
+    startRoundButton: "Start Round {{round}}",
+    gameCompletedTitle: "You completed the game! Your score: {{score}}",
+    restart: "Restart"
   },
   sci: {
     question: "Quae planta est?",
@@ -30,7 +40,12 @@ export const uiTexts = {
     resultPoints: "points",
     playAgain: "Ludere iterum",
     instruction: "Elige nomen scientificum rectum",
-    interfaceLanguageLabel: "Lingua interfaciei"
+    interfaceLanguageLabel: "Lingua interfaciei",
+    roundLabel: "Orbis",
+    roundCompleted: "Orbis {{round}} perfectus est!",
+    startRoundButton: "Incipe Orbem {{round}}",
+    gameCompletedTitle: "Ludum perfecisti! Puncta tua: {{score}}",
+    restart: "Iterum incipe"
   }
 };
 


### PR DESCRIPTION
## Summary
- add difficulty-based rounds with persistent score and dedicated transitions
- update quiz UI with round progress tracking and restart/next round controls
- extend locale strings to cover round navigation and completion messaging

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7b2cc0108832e9a3943299c7ce633