### PR TITLE
Add categorized error handling overlay for game failures

### DIFF
--- a/src/components/ErrorBoundary.js
+++ b/src/components/ErrorBoundary.js
@@ -1,0 +1,75 @@
+import { DataLoadingError, getErrorPresentation } from '../utils/errorHandling.js';
+
+const ReactGlobal = globalThis.React;
+
+if (!ReactGlobal) {
+  throw new DataLoadingError('React не найден при инициализации ErrorBoundary.');
+}
+
+const { Component, createElement, Fragment } = ReactGlobal;
+
+function ErrorContent({ error }) {
+  const presentation = getErrorPresentation(error);
+
+  return createElement(
+    'div',
+    {
+      style: {
+        padding: '32px',
+        maxWidth: '720px',
+        margin: '40px auto',
+        backgroundColor: 'rgba(30, 41, 59, 0.92)',
+        color: '#f8fafc',
+        borderRadius: '16px',
+        boxShadow: '0 20px 45px -12px rgba(15, 23, 42, 0.5)',
+        fontFamily: "'Segoe UI', system-ui, -apple-system, sans-serif"
+      }
+    },
+    createElement('h1', {
+      style: {
+        margin: '0 0 16px',
+        fontSize: '28px'
+      }
+    }, presentation.title),
+    createElement('p', {
+      style: {
+        margin: '0 0 20px',
+        fontSize: '18px',
+        lineHeight: 1.5
+      }
+    }, presentation.description),
+    createElement('p', {
+      style: {
+        margin: 0,
+        fontSize: '14px',
+        opacity: 0.85,
+        lineHeight: 1.4
+      }
+    }, `Техническая информация: ${presentation.technicalDetails}`)
+  );
+}
+
+export default class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
+
+  componentDidCatch(error) {
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent('gtp:app-error', { detail: error }));
+    }
+  }
+
+  render() {
+    if (this.state.error) {
+      return createElement(ErrorContent, { error: this.state.error });
+    }
+
+    return createElement(Fragment, null, this.props.children);
+  }
+}

--- a/src/components/PlantQuizGame.js
+++ b/src/components/PlantQuizGame.js
@@ -1,13 +1,14 @@
 import useGameLogic from '../hooks/useGameLogic.js';
 import GameScreen from './GameScreen.js';
 import ResultScreen from './ResultScreen.js';
+import { DataLoadingError } from '../utils/errorHandling.js';
 
 export default function PlantQuizGame() 
   {
   const game = useGameLogic();
   const ReactGlobal = globalThis.React;
   if (!ReactGlobal) {
-    throw new Error('React global was not found. Make sure the React bundle is loaded before rendering PlantQuizGame.');
+    throw new DataLoadingError('React не найден. Проверьте загрузку React перед запуском игры.');
   }
 
   const { createElement } = ReactGlobal;

--- a/src/gameConfig.js
+++ b/src/gameConfig.js
@@ -1,6 +1,7 @@
 import { plants } from './data/catalog.js';
 import { shuffleArray } from './utils/random.js';
 import { difficultyLevels } from './data/difficulties.js';
+import { DataLoadingError, StorageError } from './utils/errorHandling.js';
 
 export const QUESTIONS_PER_ROUND = 6;
 
@@ -19,6 +20,10 @@ export const ROUNDS = Object.freeze([
 export const TOTAL_ROUNDS = ROUNDS.length;
 
 export function getQuestionsForRound(difficulty) {
+  if (!Array.isArray(plants)) {
+    throw new DataLoadingError('Данные с растениями повреждены или не загружены.');
+  }
+
   const pool = plants.filter(plant => plant.difficulty === difficulty);
   const roundLength = Math.min(QUESTIONS_PER_ROUND, pool.length);
   if (roundLength === 0) {
@@ -32,8 +37,12 @@ export function getStoredInterfaceLanguage() {
     return null;
   }
 
-  const stored = window.localStorage.getItem(DEFAULT_LANGUAGE_STORAGE_KEY);
-  return stored && INTERFACE_LANGUAGES.includes(stored) ? stored : null;
+  try {
+    const stored = window.localStorage.getItem(DEFAULT_LANGUAGE_STORAGE_KEY);
+    return stored && INTERFACE_LANGUAGES.includes(stored) ? stored : null;
+  } catch (error) {
+    throw new StorageError('Не удалось прочитать язык интерфейса из localStorage.', { cause: error });
+  }
 }
 
 export function getStoredPlantLanguage() {
@@ -41,22 +50,34 @@ export function getStoredPlantLanguage() {
     return null;
   }
 
-  const stored = window.localStorage.getItem(PLANT_LANGUAGE_STORAGE_KEY);
-  return stored && PLANT_LANGUAGES.includes(stored) ? stored : null;
+  try {
+    const stored = window.localStorage.getItem(PLANT_LANGUAGE_STORAGE_KEY);
+    return stored && PLANT_LANGUAGES.includes(stored) ? stored : null;
+  } catch (error) {
+    throw new StorageError('Не удалось прочитать язык названий растений из localStorage.', { cause: error });
+  }
 }
 
 export function storeInterfaceLanguage(language) {
   if (typeof window === 'undefined') {
     return;
   }
-  window.localStorage.setItem(DEFAULT_LANGUAGE_STORAGE_KEY, language);
+  try {
+    window.localStorage.setItem(DEFAULT_LANGUAGE_STORAGE_KEY, language);
+  } catch (error) {
+    throw new StorageError('Не удалось сохранить язык интерфейса. Проверьте доступ к localStorage.', { cause: error });
+  }
 }
 
 export function storePlantLanguage(language) {
   if (typeof window === 'undefined') {
     return;
   }
-  window.localStorage.setItem(PLANT_LANGUAGE_STORAGE_KEY, language);
+  try {
+    window.localStorage.setItem(PLANT_LANGUAGE_STORAGE_KEY, language);
+  } catch (error) {
+    throw new StorageError('Не удалось сохранить язык названий растений. Проверьте доступ к localStorage.', { cause: error });
+  }
 }
 
 const MOBILE_BREAKPOINT = 600;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,38 @@
 import PlantQuizGame from './components/PlantQuizGame.js';
+import ErrorBoundary from './components/ErrorBoundary.js';
+import {
+  attachGlobalErrorHandlers,
+  clearFatalError,
+  renderFatalError,
+  DataLoadingError
+} from './utils/errorHandling.js';
 
-const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(React.createElement(PlantQuizGame));
+attachGlobalErrorHandlers();
+
+const mountNode = typeof document !== 'undefined' ? document.getElementById('root') : null;
+
+try {
+  if (!mountNode) {
+    throw new DataLoadingError('Не найден контейнер для приложения.');
+  }
+
+  const ReactGlobal = globalThis.React;
+  const ReactDOMGlobal = globalThis.ReactDOM;
+
+  if (!ReactGlobal || !ReactDOMGlobal) {
+    throw new DataLoadingError('Не удалось загрузить React или ReactDOM. Проверьте порядок подключения скриптов.');
+  }
+
+  clearFatalError();
+  const root = ReactDOMGlobal.createRoot(mountNode);
+  root.render(
+    ReactGlobal.createElement(
+      ErrorBoundary,
+      null,
+      ReactGlobal.createElement(PlantQuizGame)
+    )
+  );
+} catch (error) {
+  renderFatalError(error);
+  throw error;
+}

--- a/src/utils/errorHandling.js
+++ b/src/utils/errorHandling.js
@@ -1,0 +1,215 @@
+const ERROR_OVERLAY_ID = 'gtp-error-overlay';
+
+export const ERROR_TYPES = Object.freeze({
+  DATA_LOADING: 'data-loading',
+  SYNTAX: 'syntax',
+  GAME_LOGIC: 'game-logic',
+  STORAGE: 'storage'
+});
+
+export class PlantQuizError extends Error {
+  constructor(message, type, options = {}) {
+    super(message);
+    this.name = options.name || 'PlantQuizError';
+    this.type = type || ERROR_TYPES.GAME_LOGIC;
+    if (options.details) {
+      this.details = options.details;
+    }
+    if (options.cause) {
+      this.cause = options.cause;
+    }
+  }
+}
+
+export class DataLoadingError extends PlantQuizError {
+  constructor(message, options = {}) {
+    super(message, ERROR_TYPES.DATA_LOADING, { ...options, name: 'DataLoadingError' });
+  }
+}
+
+export class SyntaxRuntimeError extends PlantQuizError {
+  constructor(message, options = {}) {
+    super(message, ERROR_TYPES.SYNTAX, { ...options, name: 'SyntaxRuntimeError' });
+  }
+}
+
+export class GameLogicError extends PlantQuizError {
+  constructor(message, options = {}) {
+    super(message, ERROR_TYPES.GAME_LOGIC, { ...options, name: 'GameLogicError' });
+  }
+}
+
+export class StorageError extends PlantQuizError {
+  constructor(message, options = {}) {
+    super(message, ERROR_TYPES.STORAGE, { ...options, name: 'StorageError' });
+  }
+}
+
+export function normalizeError(error) {
+  if (!error) {
+    return new PlantQuizError('Неопознанная ошибка.', ERROR_TYPES.GAME_LOGIC);
+  }
+
+  if (error instanceof PlantQuizError) {
+    return error;
+  }
+
+  if (error instanceof SyntaxError) {
+    return new SyntaxRuntimeError(error.message, { cause: error });
+  }
+
+  if (error.name === 'QuotaExceededError' || error.name === 'SecurityError') {
+    return new StorageError(error.message, { cause: error });
+  }
+
+  if (typeof error.message === 'string' && error.message.toLowerCase().includes('localstorage')) {
+    return new StorageError(error.message, { cause: error });
+  }
+
+  if (typeof error.message === 'string' && error.message.toLowerCase().includes('syntax')) {
+    return new SyntaxRuntimeError(error.message, { cause: error });
+  }
+
+  if (typeof error.message === 'string' && error.message.toLowerCase().includes('fetch')) {
+    return new DataLoadingError(error.message, { cause: error });
+  }
+
+  return new GameLogicError(error.message || 'Неизвестная ошибка игровой логики.', { cause: error });
+}
+
+const typeMeta = {
+  [ERROR_TYPES.DATA_LOADING]: {
+    title: 'Ошибка загрузки данных',
+    description: 'Не удалось получить данные, необходимые для запуска игры. Попробуйте обновить страницу или свяжитесь с разработчиками.'
+  },
+  [ERROR_TYPES.SYNTAX]: {
+    title: 'Ошибка синтаксиса',
+    description: 'Обнаружены проблемы с кодом приложения. Пожалуйста, перезагрузите страницу. Если ошибка повторяется — сообщите о проблеме.'
+  },
+  [ERROR_TYPES.GAME_LOGIC]: {
+    title: 'Ошибка игровой логики',
+    description: 'Игре не удалось продолжить работу из-за внутренней ошибки. Попробуйте перезапустить или обратитесь к разработчикам.'
+  },
+  [ERROR_TYPES.STORAGE]: {
+    title: 'Ошибка доступа к памяти браузера',
+    description: 'Возникли проблемы с чтением или записью в localStorage. Очистите данные сайта или отключите приватный режим браузера.'
+  }
+};
+
+export function getErrorPresentation(error) {
+  const normalized = normalizeError(error);
+  const meta = typeMeta[normalized.type] || typeMeta[ERROR_TYPES.GAME_LOGIC];
+  const details = normalized.details || (normalized.cause && normalized.cause.message);
+  return {
+    error: normalized,
+    ...meta,
+    technicalDetails: details || normalized.message
+  };
+}
+
+export function renderFatalError(error) {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const presentation = getErrorPresentation(error);
+
+  let container = document.getElementById(ERROR_OVERLAY_ID);
+  if (!container) {
+    container = document.createElement('div');
+    container.id = ERROR_OVERLAY_ID;
+    container.style.position = 'fixed';
+    container.style.inset = '0';
+    container.style.backgroundColor = 'rgba(15, 23, 42, 0.92)';
+    container.style.color = '#f8fafc';
+    container.style.zIndex = '9999';
+    container.style.display = 'flex';
+    container.style.alignItems = 'center';
+    container.style.justifyContent = 'center';
+    container.style.padding = '24px';
+    container.style.boxSizing = 'border-box';
+    container.style.fontFamily = "'Segoe UI', system-ui, -apple-system, sans-serif";
+    document.body.appendChild(container);
+  }
+
+  container.innerHTML = '';
+
+  const panel = document.createElement('div');
+  panel.style.maxWidth = '560px';
+  panel.style.width = '100%';
+  panel.style.backgroundColor = 'rgba(30, 41, 59, 0.95)';
+  panel.style.borderRadius = '16px';
+  panel.style.padding = '32px';
+  panel.style.boxShadow = '0 25px 50px -12px rgba(15, 23, 42, 0.45)';
+
+  const title = document.createElement('h1');
+  title.textContent = presentation.title;
+  title.style.margin = '0 0 16px';
+  title.style.fontSize = '28px';
+  title.style.lineHeight = '1.2';
+
+  const description = document.createElement('p');
+  description.textContent = presentation.description;
+  description.style.margin = '0 0 20px';
+  description.style.fontSize = '18px';
+
+  const technical = document.createElement('p');
+  technical.textContent = `Техническая информация: ${presentation.technicalDetails}`;
+  technical.style.margin = '0';
+  technical.style.fontSize = '14px';
+  technical.style.opacity = '0.8';
+
+  panel.appendChild(title);
+  panel.appendChild(description);
+  panel.appendChild(technical);
+
+  container.appendChild(panel);
+}
+
+export function clearFatalError() {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const overlay = document.getElementById(ERROR_OVERLAY_ID);
+  if (overlay && overlay.parentNode) {
+    overlay.parentNode.removeChild(overlay);
+  }
+}
+
+let globalHandlersAttached = false;
+
+export function attachGlobalErrorHandlers() {
+  if (globalHandlersAttached || typeof window === 'undefined') {
+    return;
+  }
+
+  const handleError = error => {
+    renderFatalError(error instanceof Error ? error : new Error(String(error)));
+  };
+
+  window.addEventListener('error', event => {
+    if (event?.error) {
+      handleError(event.error);
+    } else if (event?.message) {
+      handleError(new Error(event.message));
+    }
+  });
+
+  window.addEventListener('unhandledrejection', event => {
+    const reason = event?.reason;
+    if (reason instanceof Error) {
+      handleError(reason);
+    } else {
+      handleError(new Error(typeof reason === 'string' ? reason : 'Неизвестная ошибка промиса.'));
+    }
+  });
+
+  window.addEventListener('gtp:app-error', event => {
+    if (event?.detail) {
+      handleError(event.detail);
+    }
+  });
+
+  globalHandlersAttached = true;
+}


### PR DESCRIPTION
## Summary
- add a reusable error handling utility with categorized messages and overlay renderer
- wrap the React app in an error boundary and validate critical dependencies before rendering
- surface storage, data, and game logic issues with explicit exceptions and user-facing guidance

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d850edcb60832eaf8554dedb7e4250