### PR TITLE
Add per-image difficulties for plants

### DIFF
--- a/src/hooks/useGameLogic.js
+++ b/src/hooks/useGameLogic.js
@@ -13,7 +13,8 @@ import {
   storeInterfaceLanguage,
   storePlantLanguage,
   getInitialIsMobile,
-  subscribeToViewportChange
+  subscribeToViewportChange,
+  resetUsedPlantTracking
 } from '../gameConfig.js';
 import { DataLoadingError, GameLogicError } from '../utils/errorHandling.js';
 
@@ -101,6 +102,7 @@ export default function useGameLogic() {
   }, []);
 
   const startGame = useCallback(() => {
+    resetUsedPlantTracking();
     startRound(0, true);
   }, [startRound]);
 


### PR DESCRIPTION
## Summary
- allow catalog entries to declare multiple images with optional per-image difficulty overrides
- ensure round generation skips plants that have already appeared in the current game session
- add a hard difficulty photo for rose (id 31) using the new structure

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8ff4d6a4c832eb479665396566a2a