### PR TITLE
Fix duplicate game start logic

### DIFF
--- a/src/hooks/useGameLogic.js
+++ b/src/hooks/useGameLogic.js
@@ -119,38 +119,6 @@ export default function useGameLogic() {
     startClassicGame();
   }, [startClassicGame]);
 
-  const startEndlessGame = useCallback(() => {
-    resetUsedPlantTracking();
-    setGameMode(GAME_MODES.ENDLESS);
-
-    const aggregatedQuestions = ROUNDS.reduce((acc, roundConfig, index) => {
-      prepareSeenImagesForRound(index);
-      const questions = getQuestionsForRound(roundConfig);
-      if (Array.isArray(questions) && questions.length > 0) {
-        acc.push(...questions);
-      }
-      return acc;
-    }, []);
-
-    setCurrentRoundIndex(0);
-    setSessionPlants(aggregatedQuestions);
-    setCurrentQuestionIndex(0);
-    setScore(0);
-    setGameState('playing');
-    setOptionIds([]);
-    setCorrectAnswerId(null);
-
-    if (aggregatedQuestions.length === 0) {
-      setRoundPhase('endlessComplete');
-    } else {
-      setRoundPhase('playing');
-    }
-  }, []);
-
-  const startGame = useCallback(() => {
-    startClassicGame();
-  }, [startClassicGame]);
-
   const generateOptionIds = useCallback(plant => {
     if (!plant) {
       return [];


### PR DESCRIPTION
## Summary
- remove the duplicated endless game initialization logic from `useGameLogic`
- rely on the `useEndlessMode` hook for endless mode setup to avoid runtime errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68daa8854da4832eb0cea577bde8680d