### PR TITLE
Add Google Analytics tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Викторина "Угадай растение"</title>
 
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-NETKBQ2CQQ"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-NETKBQ2CQQ');
+  </script>
+
   <!-- React UMD и Tailwind (до модуля приложения) -->
   <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>

--- a/src/hooks/useGameLogic.js
+++ b/src/hooks/useGameLogic.js
@@ -219,6 +219,26 @@ export default function useGameLogic() {
     }
   }, []);
 
+  const logAnswerSelectedEvent = useCallback((selectedId, correctId) => {
+    if (typeof window === 'undefined' || typeof window.gtag !== 'function') {
+      return;
+    }
+
+    const getChoiceLabel = id => {
+      const cell = choicesById[id];
+      if (!cell) {
+        return '';
+      }
+      return cell[plantLanguage] || cell[defaultLang] || '';
+    };
+
+    window.gtag('event', 'answer_selected', {
+      correct_answer: getChoiceLabel(correctId),
+      selected_answer: getChoiceLabel(selectedId),
+      is_correct: selectedId === correctId
+    });
+  }, [plantLanguage]);
+
   const handleAnswer = useCallback(selectedId => {
     if (roundPhase !== 'playing' || gameState !== 'playing') {
       return;
@@ -229,13 +249,17 @@ export default function useGameLogic() {
       return;
     }
 
+    if (correctAnswerId) {
+      logAnswerSelectedEvent(selectedId, correctAnswerId);
+    }
+
     if (gameMode === GAME_MODES.ENDLESS) {
       handleEndlessAnswer(selectedId, correctAnswerId);
       return;
     }
 
     handleClassicAnswer(selectedId, correctAnswerId);
-  }, [roundPhase, gameState, gameMode, correctAnswerId, currentQuestionIndex, sessionPlants, handleEndlessAnswer, handleClassicAnswer]);
+  }, [roundPhase, gameState, gameMode, correctAnswerId, currentQuestionIndex, sessionPlants, handleEndlessAnswer, handleClassicAnswer, logAnswerSelectedEvent]);
 
   const changePlantLanguage = useCallback(newLang => {
     if (!PLANT_LANGUAGES.includes(newLang)) {


### PR DESCRIPTION
## Summary
- add the Google Analytics tag to the HTML head
- log answer selection events with plant names and correctness data

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd888fdfd4832e9a09f52996f208f3