### PR TITLE
Add bouquet question type with classic mode limits

### DIFF
--- a/src/components/GameMenu.js
+++ b/src/components/GameMenu.js
@@ -65,6 +65,11 @@ export default function GameMenu({
     : isPostGame
       ? (texts.gameCompletedTitle || '').replace('{{score}}', score)
       : texts.menuTitle;
+  const subtitle = isOutOfQuestions
+    ? (texts.classicModeUnavailableSubtitle || texts.postGameSubtitle || texts.menuSubtitle || '')
+    : isPostGame
+      ? (texts.postGameSubtitle || texts.menuSubtitle || '')
+      : (texts.menuSubtitle || '');
 
   const classicLabel = texts.classicModeButton || texts.startGame || 'Start Game';
   const endlessLabel = texts.endlessModeButton || 'Endless Mode';

--- a/src/components/GameScreen.js
+++ b/src/components/GameScreen.js
@@ -226,7 +226,12 @@ export default function GameScreen({
     ? Math.min(tentativeQuestionNumber, availableQuestions)
     : tentativeQuestionNumber;
   const displayQuestionNumber = questionNumber > 0 ? questionNumber : tentativeQuestionNumber;
-  const questionHeading = texts && texts.question ? texts.question : '';
+  const questionPromptKey = currentPlant?.questionPromptKey && texts && texts[currentPlant.questionPromptKey]
+    ? currentPlant.questionPromptKey
+    : 'question';
+  const questionHeading = texts && texts[questionPromptKey]
+    ? texts[questionPromptKey]
+    : (texts && texts.question ? texts.question : '');
 
   const completedSegments = Math.min(
     totalQuestions,

--- a/src/components/PlantQuizGame.js
+++ b/src/components/PlantQuizGame.js
@@ -2,7 +2,7 @@ import useGameLogic from '../hooks/useGameLogic.js';
 import GameScreen from './GameScreen.js';
 import ResultScreen from './ResultScreen.js';
 import GameMenu from './GameMenu.js';
-import { plants } from '../data/catalog.js';
+import { allQuestions } from '../data/questions.js';
 import { DataLoadingError } from '../utils/errorHandling.js';
 
 export default function PlantQuizGame() {
@@ -12,7 +12,7 @@ export default function PlantQuizGame() {
     throw new DataLoadingError('React не найден. Проверьте загрузку React перед запуском игры.');
   }
 
-  if (!Array.isArray(plants) || plants.length === 0) {
+  if (!Array.isArray(allQuestions) || allQuestions.length === 0) {
     throw new DataLoadingError(
       'Каталог растений не загружен. Убедитесь, что data/*.js подключены как ESM-модули.'
     );

--- a/src/data/catalog.js
+++ b/src/data/catalog.js
@@ -1,6 +1,7 @@
 import { getDifficultyByQuestionId, getDifficultyByImageId } from './difficulties.js';
 import { plantNamesById } from './plantNames.js';
 import { plantImagesById } from './images.js';
+import { questionTypes } from './questionTypes.js';
 
 // Дополнительные данные для видов (кроме локализации).
 const speciesCatalog = Object.freeze({
@@ -124,16 +125,20 @@ export const plants = Object.entries(speciesById)
       .filter(imageEntry => imageEntry && typeof imageEntry.src === 'string');
 
     return imageEntries.map((imageEntry, index) => {
-        const overrideDifficulty = getDifficultyByImageId(imageEntry.id);
+      const overrideDifficulty = getDifficultyByImageId(imageEntry.id, questionTypes.PLANT);
 
-        return {
-          id: numericId,
-          imageId: imageEntry.id,
-          image: imageEntry.src,
-          names: v.names,
-          wrongAnswers: v.wrongAnswers,
-          difficulty: overrideDifficulty || getDifficultyByQuestionId(numericId),
-          questionVariantId: `${numericId}-${index}`
-        };
-      });
+      return {
+        id: numericId,
+        correctAnswerId: numericId,
+        imageId: imageEntry.id,
+        image: imageEntry.src,
+        names: v.names,
+        wrongAnswers: v.wrongAnswers,
+        difficulty: overrideDifficulty || getDifficultyByQuestionId(numericId, questionTypes.PLANT),
+        questionVariantId: `${numericId}-${index}`,
+        questionType: questionTypes.PLANT,
+        selectionGroupId: `plant-${numericId}`,
+        questionPromptKey: 'question'
+      };
+    });
   });

--- a/src/data/catalogBouquets.js
+++ b/src/data/catalogBouquets.js
@@ -1,0 +1,44 @@
+import { getDifficultyByImageId, getDifficultyByQuestionId } from './difficulties.js';
+import { plantNamesById } from './plantNames.js';
+import { questionTypes } from './questionTypes.js';
+
+const rawBouquetQuestions = Object.freeze([
+  {
+    id: 'bouquet-1',
+    imageId: 'bq001',
+    image: 'images/bouquets/pexels-kathrinepnw-25016128.jpg',
+    correctPlantId: 25,
+    wrongAnswerIds: [31, 35, 41]
+  },
+  {
+    id: 'bouquet-2',
+    imageId: 'bq002',
+    image: 'images/bouquets/pexels-pixabay-267360.jpg',
+    correctPlantId: 31,
+    wrongAnswerIds: [26, 35, 55]
+  }
+]);
+
+export const bouquetQuestions = Object.freeze(
+  rawBouquetQuestions.map(entry => {
+    const difficultyOverride = getDifficultyByImageId(entry.imageId, questionTypes.BOUQUET);
+    const fallbackDifficulty = getDifficultyByQuestionId(entry.id, questionTypes.BOUQUET);
+    const wrongAnswers = Array.isArray(entry.wrongAnswerIds)
+      ? Object.freeze(entry.wrongAnswerIds.slice(0, 3))
+      : Object.freeze([]);
+
+    return Object.freeze({
+      id: entry.correctPlantId,
+      correctAnswerId: entry.correctPlantId,
+      imageId: entry.imageId,
+      image: entry.image,
+      names: plantNamesById[entry.correctPlantId],
+      wrongAnswers,
+      difficulty: difficultyOverride || fallbackDifficulty || null,
+      questionVariantId: entry.id,
+      questionType: questionTypes.BOUQUET,
+      selectionGroupId: `bouquet-${entry.id}`,
+      questionPromptKey: 'bouquetQuestion'
+    });
+  })
+);

--- a/src/data/difficulties.js
+++ b/src/data/difficulties.js
@@ -1,43 +1,70 @@
+import { questionTypes } from './questionTypes.js';
+
 export const difficultyLevels = Object.freeze({
   EASY: 'Easy',
   MEDIUM: 'Medium',
   HARD: 'Hard'
 });
 
-export const questionIdsByDifficulty = Object.freeze({
+const plantQuestionIdsByDifficulty = Object.freeze({
   [difficultyLevels.EASY]: Object.freeze([6, 12, 13, 22, 26, 27, 29, 31, 33, 35, 41, 51, 55, 58, 75, 82, 88, 91, 93, 94, 95, 97, 100]),
   [difficultyLevels.MEDIUM]: Object.freeze([2, 3, 5, 8, 17, 19, 21, 26, 30, 36, 46, 47, 54, 62, 68, 69, 72, 73, 81, 83, 85, 86, 90, 92, 96, 98, 101]),
   [difficultyLevels.HARD]: Object.freeze([1, 4, 32, 34, 50, 53, 52, 77, 78, 79, 80, 84, 89])
 });
 
-export const imageIdsByDifficulty = Object.freeze({
-    [difficultyLevels.EASY]: Object.freeze(['p092']),
-    [difficultyLevels.MEDIUM]: Object.freeze(['p011', 'p014', 'p021', 'p035', 'p044', 'p060', 'p050', 'p078','p082', 'p097', 'p104', 'p133']),
-    [difficultyLevels.HARD]: Object.freeze(['p018', 'p067', 'p072', 'p074', 'p046', 'p047', 'p054', 'p063', 'p064', 'p073', 'p095','p096', 'p100', 'p109', 'p110', 'p111', 'p112']),
+const bouquetQuestionIdsByDifficulty = Object.freeze({
+  [difficultyLevels.MEDIUM]: Object.freeze(['bouquet-1', 'bouquet-2'])
 });
 
-export const imageDifficultyOverrides = Object.freeze(
-  Object.entries(imageIdsByDifficulty).reduce((acc, [difficulty, ids]) => {
-    ids.forEach(id => {
-      acc[id] = difficulty;
-    });
-    return acc;
-  }, {})
-);
+export const questionIdsByDifficulty = Object.freeze({
+  [questionTypes.PLANT]: plantQuestionIdsByDifficulty,
+  [questionTypes.BOUQUET]: bouquetQuestionIdsByDifficulty
+});
 
-const difficultyByQuestionId = Object.freeze(
-  Object.entries(questionIdsByDifficulty).reduce((acc, [difficulty, ids]) => {
-    ids.forEach(id => {
-      acc[id] = difficulty;
-    });
-    return acc;
-  }, {})
-);
+const plantImageIdsByDifficulty = Object.freeze({
+  [difficultyLevels.EASY]: Object.freeze(['p092']),
+  [difficultyLevels.MEDIUM]: Object.freeze(['p011', 'p014', 'p021', 'p035', 'p044', 'p050', 'p060', 'p078', 'p082', 'p097', 'p104', 'p133']),
+  [difficultyLevels.HARD]: Object.freeze(['p018', 'p046', 'p047', 'p054', 'p063', 'p064', 'p067', 'p072', 'p073', 'p074', 'p095', 'p096', 'p100', 'p109', 'p110', 'p111', 'p112'])
+});
 
-export function getDifficultyByQuestionId(questionId) {
-  return difficultyByQuestionId[questionId] || null;
+const bouquetImageIdsByDifficulty = Object.freeze({
+  [difficultyLevels.MEDIUM]: Object.freeze(['bq001', 'bq002'])
+});
+
+export const imageIdsByDifficulty = Object.freeze({
+  [questionTypes.PLANT]: plantImageIdsByDifficulty,
+  [questionTypes.BOUQUET]: bouquetImageIdsByDifficulty
+});
+
+function buildDifficultyLookup(source) {
+  return Object.freeze(
+    Object.fromEntries(
+      Object.entries(source).flatMap(([questionType, difficultyMap]) =>
+        Object.entries(difficultyMap).flatMap(([difficulty, ids]) =>
+          ids.map(id => [`${questionType}::${id}`, difficulty])
+        )
+      )
+    )
+  );
 }
 
-export function getDifficultyByImageId(imageId) {
-  return imageDifficultyOverrides[imageId] || null;
+const questionDifficultyLookup = buildDifficultyLookup(questionIdsByDifficulty);
+const imageDifficultyLookup = buildDifficultyLookup(imageIdsByDifficulty);
+
+export const imageDifficultyOverrides = imageDifficultyLookup;
+
+export function getDifficultyByQuestionId(questionId, questionType = questionTypes.PLANT) {
+  if (questionId == null) {
+    return null;
+  }
+
+  return questionDifficultyLookup[`${questionType}::${questionId}`] || null;
+}
+
+export function getDifficultyByImageId(imageId, questionType = questionTypes.PLANT) {
+  if (typeof imageId !== 'string') {
+    return null;
+  }
+
+  return imageDifficultyLookup[`${questionType}::${imageId}`] || null;
 }

--- a/src/data/questionTypes.js
+++ b/src/data/questionTypes.js
@@ -1,0 +1,4 @@
+export const questionTypes = Object.freeze({
+  PLANT: 'plant',
+  BOUQUET: 'bouquet'
+});

--- a/src/data/questions.js
+++ b/src/data/questions.js
@@ -1,0 +1,7 @@
+import { bouquetQuestions } from './catalogBouquets.js';
+import { plants } from './catalog.js';
+
+export const allQuestions = Object.freeze([
+  ...plants,
+  ...bouquetQuestions
+]);

--- a/src/hooks/useClassicMode.js
+++ b/src/hooks/useClassicMode.js
@@ -31,7 +31,11 @@ export function useClassicMode({
     throw new GameLogicError('React не найден. Проверьте загрузку React перед запуском приложения.');
   }
 
-  const { useCallback } = ReactGlobal;
+  const { useCallback, useRef } = ReactGlobal;
+
+  const BOUQUET_QUESTIONS_TARGET = 2;
+  const BOUQUET_PER_ROUND_LIMIT = 1;
+  const bouquetQuestionsRemainingRef = useRef(BOUQUET_QUESTIONS_TARGET);
 
   const startRound = useCallback((roundIndex, resetScore = false) => {
     const roundConfig = ROUNDS[roundIndex];
@@ -41,7 +45,22 @@ export function useClassicMode({
 
     prepareSeenImagesForRound(roundIndex);
 
-    const questions = getQuestionsForRound(roundConfig);
+    if (resetScore) {
+      bouquetQuestionsRemainingRef.current = BOUQUET_QUESTIONS_TARGET;
+    }
+
+    const questions = getQuestionsForRound(roundConfig, {
+      bouquetRemaining: bouquetQuestionsRemainingRef.current,
+      bouquetPerRoundLimit: BOUQUET_PER_ROUND_LIMIT,
+      afterSelection: ({ bouquetCount = 0 } = {}) => {
+        if (bouquetCount > 0) {
+          bouquetQuestionsRemainingRef.current = Math.max(
+            0,
+            bouquetQuestionsRemainingRef.current - bouquetCount
+          );
+        }
+      }
+    });
     setCurrentRoundIndex(roundIndex);
 
     if (resetScore) {

--- a/src/hooks/useEndlessMode.js
+++ b/src/hooks/useEndlessMode.js
@@ -1,5 +1,5 @@
 import { GAME_MODES, resetUsedPlantTracking } from '../gameConfig.js';
-import { plants } from '../data/catalog.js';
+import { allQuestions } from '../data/questions.js';
 import { shuffleArray } from '../utils/random.js';
 import { GameLogicError } from '../utils/errorHandling.js';
 
@@ -30,7 +30,7 @@ export function useEndlessMode({
     resetUsedPlantTracking();
     setGameMode(GAME_MODES.ENDLESS);
 
-    const aggregatedQuestions = shuffleArray(plants);
+    const aggregatedQuestions = shuffleArray(allQuestions);
 
     setCurrentRoundIndex(0);
     setSessionPlants(aggregatedQuestions);

--- a/src/i18n/uiTexts.js
+++ b/src/i18n/uiTexts.js
@@ -1,6 +1,7 @@
 export const uiTexts = {
   ru: {
     question: "Что это за растение?",
+    bouquetQuestion: "Какого цветка нет в букете?",
     score: "Баллы",
     correct: "Верно!",
     incorrect: "Неверно!",
@@ -33,6 +34,7 @@ export const uiTexts = {
   },
   en: {
     question: "What plant is this?",
+    bouquetQuestion: "Which flower is missing from the bouquet?",
     score: "Score",
     correct: "Correct!",
     incorrect: "Incorrect!",
@@ -65,6 +67,7 @@ export const uiTexts = {
   },
   nl: {
     question: "Wat is deze plant?",
+    bouquetQuestion: "Welke bloem zit niet in het boeket?",
     score: "Score",
     correct: "Goed!",
     incorrect: "Fout!",

--- a/src/voiceMode/VoiceModeScreen.js
+++ b/src/voiceMode/VoiceModeScreen.js
@@ -91,7 +91,7 @@ export default function VoiceModeScreen({
   }
 
   const { createElement, useEffect, useMemo, useState } = ReactGlobal;
-  const { repeatAnnouncements } = useVoiceAnnouncements({ questionNumber, options, gameState });
+  const { repeatOptions } = useVoiceAnnouncements({ questionNumber, options, gameState });
   const isInteractionLocked = gameState !== 'playing';
 
   useEffect(() => {
@@ -150,7 +150,7 @@ export default function VoiceModeScreen({
       }
 
       if (REPEAT_PATTERNS.some(pattern => pattern.test(sanitized))) {
-        repeatAnnouncements();
+        repeatOptions();
         return;
       }
 
@@ -204,7 +204,7 @@ export default function VoiceModeScreen({
         }
       }
     };
-  }, [gameState, options, onAnswer, repeatAnnouncements]);
+  }, [gameState, options, onAnswer, repeatOptions]);
   useVoiceCommands({
     enabled: !isInteractionLocked,
     options,


### PR DESCRIPTION
## Summary
- add a dedicated bouquet question catalog and hook it into the shared question pool
- update difficulty mappings and classic mode selection to respect bouquet quotas and per-round limits
- surface bouquet-specific prompts in the UI while keeping shared answer options

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd9d5be0bc832eba5b9b0c49b959af