### PR TITLE
Restrict plant language options to interface language and sci

### DIFF
--- a/src/components/GameHeader.js
+++ b/src/components/GameHeader.js
@@ -1,4 +1,4 @@
-import { PLANT_LANGUAGES, GAME_MODES } from '../gameConfig.js';
+import { GAME_MODES } from '../gameConfig.js';
 
 export default function GameHeader({
   texts,
@@ -7,7 +7,8 @@ export default function GameHeader({
   plantLanguage,
   onPlantLanguageChange,
   showLanguageSelector = true,
-  gameMode = GAME_MODES.CLASSIC
+  gameMode = GAME_MODES.CLASSIC,
+  interfaceLanguage
 }) {
   const ReactGlobal = globalThis.React;
   if (!ReactGlobal) {
@@ -38,10 +39,15 @@ export default function GameHeader({
 
   let languageButtons = null;
   if (showLanguageSelector && typeof onPlantLanguageChange === 'function') {
+    const availablePlantLanguages = Array.from(new Set([
+      interfaceLanguage,
+      'sci'
+    ].filter(Boolean)));
+
     languageButtons = createElement('div', {
       key: 'lang-buttons',
       className: 'flex gap-2'
-    }, PLANT_LANGUAGES.map(lang => createElement('button', {
+    }, availablePlantLanguages.map(lang => createElement('button', {
       key: lang,
       onClick: () => onPlantLanguageChange(lang),
       className: 'px-2.5 py-1 text-xs font-bold uppercase transition-all tracking-wide',

--- a/src/components/GameScreen.js
+++ b/src/components/GameScreen.js
@@ -204,7 +204,8 @@ export default function GameScreen({
   plantLanguage,
   onAnswer,
   onPlantLanguageChange,
-  gameMode
+  gameMode,
+  interfaceLanguage
 }) {
   const ReactGlobal = globalThis.React;
   if (!ReactGlobal) {
@@ -347,7 +348,8 @@ export default function GameScreen({
       totalQuestions,
       plantLanguage,
       onPlantLanguageChange,
-      gameMode
+      gameMode,
+      interfaceLanguage
     }),
     content
   ].filter(Boolean));

--- a/src/components/PlantQuizGame.js
+++ b/src/components/PlantQuizGame.js
@@ -50,7 +50,8 @@ export default function PlantQuizGame() {
       plantLanguage: game.plantLanguage,
       onAnswer: game.handleAnswer,
       onPlantLanguageChange: game.changePlantLanguage,
-      gameMode: game.gameMode
+      gameMode: game.gameMode,
+      interfaceLanguage: game.interfaceLanguage
     });
   }
 
@@ -68,6 +69,7 @@ export default function PlantQuizGame() {
     onStartNextRound: game.handleStartNextRound,
     onRestart: isEndlessPhase ? game.startEndlessGame : game.startGame,
     onReturnToMenu: game.returnToMenu,
-    gameMode: game.gameMode
+    gameMode: game.gameMode,
+    interfaceLanguage: game.interfaceLanguage
   });
 }

--- a/src/components/ResultScreen.js
+++ b/src/components/ResultScreen.js
@@ -143,7 +143,8 @@ export default function ResultScreen({
   onStartNextRound,
   onRestart,
   gameMode = GAME_MODES.CLASSIC,
-  onReturnToMenu
+  onReturnToMenu,
+  interfaceLanguage
 }) {
   const ReactGlobal = globalThis.React;
   if (!ReactGlobal) {
@@ -185,7 +186,8 @@ export default function ResultScreen({
       plantLanguage,
       onPlantLanguageChange,
       gameMode,
-      showQuestionProgress: false
+      showQuestionProgress: false,
+      interfaceLanguage
     }),
     createElement('div', {
       key: 'main',


### PR DESCRIPTION
## Summary
- limit plant-language selector to the interface language and scientific Latin option
- synchronize stored plant-language preference with the chosen interface language
- propagate the interface language to screens so selectors render the correct options

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de28b7d01c832e8d50df2598e71c48