### PR TITLE
Fix GameMenu subtitle declaration crash

### DIFF
--- a/src/components/GameMenu.js
+++ b/src/components/GameMenu.js
@@ -65,15 +65,12 @@ export default function GameMenu({
     : isPostGame
       ? (texts.gameCompletedTitle || '').replace('{{score}}', score)
       : texts.menuTitle;
+
   const subtitle = isOutOfQuestions
     ? (texts.classicModeUnavailableSubtitle || texts.postGameSubtitle || texts.menuSubtitle || '')
     : isPostGame
       ? (texts.postGameSubtitle || texts.menuSubtitle || '')
       : (texts.menuSubtitle || '');
-
-  const subtitle = isOutOfQuestions
-    ? (texts.classicModeUnavailableSubtitle ?? texts.menuSubtitle ?? '')
-    : (texts.menuSubtitle ?? '');
 
   const classicLabel = texts.classicModeButton || texts.startGame || 'Start Game';
   const endlessLabel = texts.endlessModeButton || 'Endless Mode';


### PR DESCRIPTION
## Summary
- remove the duplicate `subtitle` constant in `GameMenu` so the component can render without throwing a runtime error

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de2ebd2818832ea2de82a93b1e32a8