### PR TITLE
Add compatibility polyfills for Android browsers

### DIFF
--- a/src/components/GameScreen.js
+++ b/src/components/GameScreen.js
@@ -215,7 +215,7 @@ export default function GameScreen({
   }
 
   const { createElement } = ReactGlobal;
-  const isBouquetQuestion = currentPlant?.questionType === questionTypes.BOUQUET;
+  const isBouquetQuestion = currentPlant && currentPlant.questionType === questionTypes.BOUQUET;
   const interfaceAccentColor = isBouquetQuestion ? '#C9A9A6' : '#C29C27';
   const interfaceAccentColorTransparent = isBouquetQuestion
     ? 'rgba(201, 169, 166, 0.4)'
@@ -234,8 +234,12 @@ export default function GameScreen({
     ? Math.min(tentativeQuestionNumber, availableQuestions)
     : tentativeQuestionNumber;
   const displayQuestionNumber = questionNumber > 0 ? questionNumber : tentativeQuestionNumber;
-  const questionPromptKey = currentPlant?.questionPromptKey && texts && texts[currentPlant.questionPromptKey]
+  const plantQuestionKey = currentPlant && currentPlant.questionPromptKey
     ? currentPlant.questionPromptKey
+    : null;
+  const hasCustomPrompt = plantQuestionKey && texts && Object.prototype.hasOwnProperty.call(texts, plantQuestionKey);
+  const questionPromptKey = hasCustomPrompt
+    ? plantQuestionKey
     : 'question';
   const questionHeading = texts && texts[questionPromptKey]
     ? texts[questionPromptKey]

--- a/src/i18n/uiTexts.js
+++ b/src/i18n/uiTexts.js
@@ -103,6 +103,10 @@ export const uiTexts = {
 export const defaultLang = 'ru';
 
 export function t(lang) {
-  return uiTexts[lang] ?? uiTexts[defaultLang];
+  const candidate = uiTexts[lang];
+  if (candidate && typeof candidate === 'object') {
+    return candidate;
+  }
+  return uiTexts[defaultLang];
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import './polyfills.js';
 import PlantQuizGame from './components/PlantQuizGame.js';
 import ErrorBoundary from './components/ErrorBoundary.js';
 import {

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -1,0 +1,98 @@
+(function applyPolyfills() {
+  if (typeof globalThis === 'undefined') {
+    const getGlobal = function() {
+      if (typeof self !== 'undefined') {
+        return self;
+      }
+      if (typeof window !== 'undefined') {
+        return window;
+      }
+      return {};
+    };
+    const globalObject = getGlobal();
+    Object.defineProperty(globalObject, 'globalThis', {
+      value: globalObject,
+      writable: true,
+      configurable: true
+    });
+  }
+
+  if (typeof Object.fromEntries !== 'function') {
+    Object.fromEntries = function fromEntries(entries) {
+      if (entries == null) {
+        throw new TypeError('Object.fromEntries requires an iterable.');
+      }
+
+      const result = {};
+      const isIterable = typeof Symbol !== 'undefined' && Symbol.iterator && typeof entries[Symbol.iterator] === 'function';
+
+      if (isIterable) {
+        const iterator = entries[Symbol.iterator]();
+        let step = iterator.next();
+        while (!step.done) {
+          const pair = step.value;
+          if (pair && pair.length > 0) {
+            result[pair[0]] = pair.length > 1 ? pair[1] : undefined;
+          }
+          step = iterator.next();
+        }
+        return result;
+      }
+
+      if (typeof entries.forEach === 'function') {
+        entries.forEach(pair => {
+          if (pair && pair.length > 0) {
+            result[pair[0]] = pair.length > 1 ? pair[1] : undefined;
+          }
+        });
+        return result;
+      }
+
+      if (typeof entries.length === 'number') {
+        for (let i = 0; i < entries.length; i += 1) {
+          const pair = entries[i];
+          if (pair && pair.length > 0) {
+            result[pair[0]] = pair.length > 1 ? pair[1] : undefined;
+          }
+        }
+        return result;
+      }
+
+      throw new TypeError('Object.fromEntries requires an iterable, array-like object, or forEach method.');
+    };
+  }
+
+  if (typeof Array.prototype.flatMap !== 'function') {
+    Object.defineProperty(Array.prototype, 'flatMap', {
+      value: function flatMap(callback, thisArg) {
+        if (this == null) {
+          throw new TypeError('Array.prototype.flatMap called on null or undefined.');
+        }
+        if (typeof callback !== 'function') {
+          throw new TypeError('Callback provided to flatMap must be a function.');
+        }
+
+        const O = Object(this);
+        const len = Math.max(Math.min(Number(O.length) || 0, Number.MAX_SAFE_INTEGER), 0);
+        const result = [];
+
+        for (let k = 0; k < len; k += 1) {
+          if (Object.prototype.hasOwnProperty.call(O, k)) {
+            const part = callback.call(thisArg, O[k], k, O);
+            if (Array.isArray(part)) {
+              for (let j = 0; j < part.length; j += 1) {
+                result.push(part[j]);
+              }
+            } else {
+              result.push(part);
+            }
+          }
+        }
+
+        return result;
+      },
+      configurable: true,
+      writable: true
+    });
+  }
+})();

--- a/src/utils/errorHandling.js
+++ b/src/utils/errorHandling.js
@@ -189,15 +189,15 @@ export function attachGlobalErrorHandlers() {
   };
 
   window.addEventListener('error', event => {
-    if (event?.error) {
+    if (event && event.error) {
       handleError(event.error);
-    } else if (event?.message) {
+    } else if (event && typeof event.message === 'string') {
       handleError(new Error(event.message));
     }
   });
 
   window.addEventListener('unhandledrejection', event => {
-    const reason = event?.reason;
+    const reason = event ? event.reason : undefined;
     if (reason instanceof Error) {
       handleError(reason);
     } else {
@@ -206,7 +206,7 @@ export function attachGlobalErrorHandlers() {
   });
 
   window.addEventListener('gtp:app-error', event => {
-    if (event?.detail) {
+    if (event && event.detail) {
       handleError(event.detail);
     }
   });


### PR DESCRIPTION
## Summary
- add lightweight runtime polyfills for `globalThis`, `Object.fromEntries`, and `Array.prototype.flatMap` so legacy Android browsers can execute the scripts
- replace optional chaining/nullish coalescing in the main game modules with broadly supported patterns
- harden global error handlers against older event objects so fatal errors surface reliably

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68deaf21abd0832eaea8c1bb577528b0