### PR TITLE
Inline Tailwind-style utilities for legacy Android browsers

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,10 +14,10 @@
     gtag('config', 'G-NETKBQ2CQQ');
   </script>
 
-  <!-- React UMD и Tailwind (до модуля приложения) -->
+  <!-- React UMD (до модуля приложения) -->
   <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
-  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="./styles/utilities.css" />
   
   <style>
     body {

--- a/src/components/GameScreen.js
+++ b/src/components/GameScreen.js
@@ -215,7 +215,7 @@ export default function GameScreen({
   }
 
   const { createElement } = ReactGlobal;
-  const isBouquetQuestion = currentPlant?.questionType === questionTypes.BOUQUET;
+  const isBouquetQuestion = currentPlant && currentPlant.questionType === questionTypes.BOUQUET;
   const interfaceAccentColor = isBouquetQuestion ? '#C9A9A6' : '#C29C27';
   const interfaceAccentColorTransparent = isBouquetQuestion
     ? 'rgba(201, 169, 166, 0.4)'
@@ -234,8 +234,12 @@ export default function GameScreen({
     ? Math.min(tentativeQuestionNumber, availableQuestions)
     : tentativeQuestionNumber;
   const displayQuestionNumber = questionNumber > 0 ? questionNumber : tentativeQuestionNumber;
-  const questionPromptKey = currentPlant?.questionPromptKey && texts && texts[currentPlant.questionPromptKey]
+  const plantQuestionKey = currentPlant && currentPlant.questionPromptKey
     ? currentPlant.questionPromptKey
+    : null;
+  const hasCustomPrompt = plantQuestionKey && texts && Object.prototype.hasOwnProperty.call(texts, plantQuestionKey);
+  const questionPromptKey = hasCustomPrompt
+    ? plantQuestionKey
     : 'question';
   const questionHeading = texts && texts[questionPromptKey]
     ? texts[questionPromptKey]

--- a/src/i18n/uiTexts.js
+++ b/src/i18n/uiTexts.js
@@ -103,6 +103,10 @@ export const uiTexts = {
 export const defaultLang = 'ru';
 
 export function t(lang) {
-  return uiTexts[lang] ?? uiTexts[defaultLang];
+  const candidate = uiTexts[lang];
+  if (candidate && typeof candidate === 'object') {
+    return candidate;
+  }
+  return uiTexts[defaultLang];
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import './polyfills.js';
 import PlantQuizGame from './components/PlantQuizGame.js';
 import ErrorBoundary from './components/ErrorBoundary.js';
 import {

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -1,0 +1,98 @@
+(function applyPolyfills() {
+  if (typeof globalThis === 'undefined') {
+    const getGlobal = function() {
+      if (typeof self !== 'undefined') {
+        return self;
+      }
+      if (typeof window !== 'undefined') {
+        return window;
+      }
+      return {};
+    };
+    const globalObject = getGlobal();
+    Object.defineProperty(globalObject, 'globalThis', {
+      value: globalObject,
+      writable: true,
+      configurable: true
+    });
+  }
+
+  if (typeof Object.fromEntries !== 'function') {
+    Object.fromEntries = function fromEntries(entries) {
+      if (entries == null) {
+        throw new TypeError('Object.fromEntries requires an iterable.');
+      }
+
+      const result = {};
+      const isIterable = typeof Symbol !== 'undefined' && Symbol.iterator && typeof entries[Symbol.iterator] === 'function';
+
+      if (isIterable) {
+        const iterator = entries[Symbol.iterator]();
+        let step = iterator.next();
+        while (!step.done) {
+          const pair = step.value;
+          if (pair && pair.length > 0) {
+            result[pair[0]] = pair.length > 1 ? pair[1] : undefined;
+          }
+          step = iterator.next();
+        }
+        return result;
+      }
+
+      if (typeof entries.forEach === 'function') {
+        entries.forEach(pair => {
+          if (pair && pair.length > 0) {
+            result[pair[0]] = pair.length > 1 ? pair[1] : undefined;
+          }
+        });
+        return result;
+      }
+
+      if (typeof entries.length === 'number') {
+        for (let i = 0; i < entries.length; i += 1) {
+          const pair = entries[i];
+          if (pair && pair.length > 0) {
+            result[pair[0]] = pair.length > 1 ? pair[1] : undefined;
+          }
+        }
+        return result;
+      }
+
+      throw new TypeError('Object.fromEntries requires an iterable, array-like object, or forEach method.');
+    };
+  }
+
+  if (typeof Array.prototype.flatMap !== 'function') {
+    Object.defineProperty(Array.prototype, 'flatMap', {
+      value: function flatMap(callback, thisArg) {
+        if (this == null) {
+          throw new TypeError('Array.prototype.flatMap called on null or undefined.');
+        }
+        if (typeof callback !== 'function') {
+          throw new TypeError('Callback provided to flatMap must be a function.');
+        }
+
+        const O = Object(this);
+        const len = Math.max(Math.min(Number(O.length) || 0, Number.MAX_SAFE_INTEGER), 0);
+        const result = [];
+
+        for (let k = 0; k < len; k += 1) {
+          if (Object.prototype.hasOwnProperty.call(O, k)) {
+            const part = callback.call(thisArg, O[k], k, O);
+            if (Array.isArray(part)) {
+              for (let j = 0; j < part.length; j += 1) {
+                result.push(part[j]);
+              }
+            } else {
+              result.push(part);
+            }
+          }
+        }
+
+        return result;
+      },
+      configurable: true,
+      writable: true
+    });
+  }
+})();

--- a/src/utils/errorHandling.js
+++ b/src/utils/errorHandling.js
@@ -189,15 +189,15 @@ export function attachGlobalErrorHandlers() {
   };
 
   window.addEventListener('error', event => {
-    if (event?.error) {
+    if (event && event.error) {
       handleError(event.error);
-    } else if (event?.message) {
+    } else if (event && typeof event.message === 'string') {
       handleError(new Error(event.message));
     }
   });
 
   window.addEventListener('unhandledrejection', event => {
-    const reason = event?.reason;
+    const reason = event ? event.reason : undefined;
     if (reason instanceof Error) {
       handleError(reason);
     } else {
@@ -206,7 +206,7 @@ export function attachGlobalErrorHandlers() {
   });
 
   window.addEventListener('gtp:app-error', event => {
-    if (event?.detail) {
+    if (event && event.detail) {
       handleError(event.detail);
     }
   });

--- a/src/voiceMode/VoiceModeScreen.js
+++ b/src/voiceMode/VoiceModeScreen.js
@@ -54,8 +54,16 @@ function VoicePlantImage({ src, alt, containerStyle, sectionStyle }) {
         pointerEvents: 'none'
       },
       draggable: false,
-      onContextMenu: event => event?.preventDefault?.(),
-      onDragStart: event => event?.preventDefault?.()
+      onContextMenu: event => {
+        if (event && typeof event.preventDefault === 'function') {
+          event.preventDefault();
+        }
+      },
+      onDragStart: event => {
+        if (event && typeof event.preventDefault === 'function') {
+          event.preventDefault();
+        }
+      }
     })
     : createElement('div', {
       role: 'status',
@@ -120,20 +128,22 @@ export default function VoiceModeScreen({
       try {
         recognition.start();
       } catch (error) {
-        if (error?.name !== 'InvalidStateError') {
+        if (!error || error.name !== 'InvalidStateError') {
           console.error('Не удалось запустить распознавание речи.', error);
         }
       }
     };
 
     recognition.onresult = event => {
-      if (!event?.results || event.results.length === 0) {
+      if (!event || !event.results || event.results.length === 0) {
         return;
       }
 
       const lastResult = event.results[event.results.length - 1];
       const alternative = lastResult && lastResult[0];
-      const transcript = typeof alternative?.transcript === 'string' ? alternative.transcript : '';
+      const transcript = alternative && typeof alternative.transcript === 'string'
+        ? alternative.transcript
+        : '';
       const normalized = transcript.trim().toLowerCase();
 
       if (!normalized) {
@@ -164,7 +174,7 @@ export default function VoiceModeScreen({
           continue;
         }
 
-        const option = options?.[command.index];
+        const option = options && options.length > command.index ? options[command.index] : undefined;
         if (option && typeof onAnswer === 'function') {
           onAnswer(option.id);
         }
@@ -173,7 +183,7 @@ export default function VoiceModeScreen({
     };
 
     recognition.onerror = event => {
-      if (event?.error === 'no-speech') {
+      if (event && event.error === 'no-speech') {
         return;
       }
 
@@ -199,7 +209,7 @@ export default function VoiceModeScreen({
       try {
         recognition.stop();
       } catch (error) {
-        if (error?.name !== 'InvalidStateError') {
+        if (!error || error.name !== 'InvalidStateError') {
           console.error('Не удалось остановить распознавание речи.', error);
         }
       }
@@ -210,7 +220,7 @@ export default function VoiceModeScreen({
     options,
     onAnswer,
     onRepeat: repeatOptions,
-    questionId: currentPlant?.id || `${questionNumber}`
+    questionId: currentPlant && currentPlant.id ? currentPlant.id : `${questionNumber}`
   });
 
   const feedbackState = useMemo(() => {
@@ -334,7 +344,7 @@ export default function VoiceModeScreen({
     currentPlant && currentPlant.image && createElement(VoicePlantImage, {
       key: 'image',
       src: currentPlant.image,
-      alt: currentPlant?.ru ? `Растение: ${currentPlant.ru}` : 'Фотография растения',
+      alt: currentPlant && currentPlant.ru ? `Растение: ${currentPlant.ru}` : 'Фотография растения',
       containerStyle: imageContainerStyle,
       sectionStyle: imageSectionStyle
     }),

--- a/styles/utilities.css
+++ b/styles/utilities.css
@@ -1,0 +1,134 @@
+/* Minimal utility classes to replace Tailwind CDN for legacy browsers */
+.min-h-screen { min-height: 100vh; }
+.relative { position: relative; }
+.absolute { position: absolute; }
+.flex { display: flex; }
+.grid { display: grid; }
+.flex-col { flex-direction: column; }
+.flex-wrap { flex-wrap: wrap; }
+.flex-1 { flex: 1 1 0%; }
+.items-center { align-items: center; }
+.items-end { align-items: flex-end; }
+.justify-center { justify-content: center; }
+.justify-between { justify-content: space-between; }
+.pointer-events-none { pointer-events: none; }
+.overflow-hidden { overflow: hidden; }
+.w-full { width: 100%; }
+.h-full { height: 100%; }
+.grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+.grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.text-center { text-align: center; }
+.text-base { font-size: 1rem; line-height: 1.5rem; }
+.text-sm { font-size: 0.875rem; line-height: 1.25rem; }
+.text-xs { font-size: 0.75rem; line-height: 1rem; }
+.text-lg { font-size: 1.125rem; line-height: 1.75rem; }
+.text-xl { font-size: 1.25rem; line-height: 1.75rem; }
+.text-2xl { font-size: 1.5rem; line-height: 2rem; }
+.text-3xl { font-size: 1.875rem; line-height: 2.25rem; }
+.text-6xl { font-size: 3.75rem; line-height: 1; }
+.font-normal { font-weight: 400; }
+.font-semibold { font-weight: 600; }
+.font-bold { font-weight: 700; }
+.font-extrabold { font-weight: 800; }
+.uppercase { text-transform: uppercase; }
+.tracking-wide { letter-spacing: 0.05em; }
+.leading-relaxed { line-height: 1.625; }
+.whitespace-nowrap { white-space: nowrap; }
+.shadow-lg { box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1); }
+.rounded-full { border-radius: 9999px; }
+.rounded-2xl { border-radius: 1rem; }
+.transition-all { transition-property: all; transition-duration: 150ms; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
+.transition-colors { transition-property: color, background-color, border-color, text-decoration-color, fill, stroke; transition-duration: 150ms; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
+.duration-200 { transition-duration: 200ms; }
+.object-cover { object-fit: cover; }
+.cursor-pointer { cursor: pointer; }
+.z-10 { z-index: 10; }
+.z-20 { z-index: 20; }
+.inset-0 { top: 0; right: 0; bottom: 0; left: 0; }
+.top-8 { top: 2rem; }
+.bottom-8 { bottom: 2rem; }
+.left-0 { left: 0; }
+.right-0 { right: 0; }
+.right-12 { right: 3rem; }
+.mx-auto { margin-left: auto; margin-right: auto; }
+.mx-4 { margin-left: 1rem; margin-right: 1rem; }
+.mb-4 { margin-bottom: 1rem; }
+.mb-6 { margin-bottom: 1.5rem; }
+.mb-8 { margin-bottom: 2rem; }
+.mt-auto { margin-top: auto; }
+.p-8 { padding: 2rem; }
+.py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
+.py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
+.py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
+.py-4 { padding-top: 1rem; padding-bottom: 1rem; }
+.py-6 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
+.py-8 { padding-top: 2rem; padding-bottom: 2rem; }
+.py-10 { padding-top: 2.5rem; padding-bottom: 2.5rem; }
+.px-2\.5 { padding-left: 0.625rem; padding-right: 0.625rem; }
+.px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
+.px-4 { padding-left: 1rem; padding-right: 1rem; }
+.px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
+.px-8 { padding-left: 2rem; padding-right: 2rem; }
+.px-10 { padding-left: 2.5rem; padding-right: 2.5rem; }
+.px-12 { padding-left: 3rem; padding-right: 3rem; }
+.max-w-md { max-width: 28rem; }
+.max-w-xl { max-width: 36rem; }
+.max-w-2xl { max-width: 42rem; }
+.max-w-3xl { max-width: 48rem; }
+.max-w-5xl { max-width: 64rem; }
+.max-w-6xl { max-width: 72rem; }
+.gap-2 { gap: 0.5rem; }
+.gap-3 { gap: 0.75rem; }
+.gap-4 { gap: 1rem; }
+.gap-6 { gap: 1.5rem; }
+.gap-8 { gap: 2rem; }
+.gap-10 { gap: 2.5rem; }
+.bg-\[\#C29C27\] { background-color: #c29c27; }
+.bg-emerald-500 { background-color: #10b981; }
+.bg-emerald-900 { background-color: #064e3b; }
+.bg-emerald-950 { background-color: #022c22; }
+.text-white { color: #ffffff; }
+.text-emerald-50 { color: #ecfdf5; }
+.text-emerald-100 { color: #d1fae5; }
+.text-emerald-900 { color: #064e3b; }
+.text-emerald-950 { color: #022c22; }
+.border { border-width: 1px; border-style: solid; border-color: #e5e7eb; }
+.border-emerald-400 { border-color: #34d399; }
+.hover\:opacity-80:hover { opacity: 0.8; }
+.hover\:scale-105:hover { transform: scale(1.05); }
+.hover\:bg-emerald-400:hover { background-color: #34d399; }
+.hover\:bg-emerald-800:hover { background-color: #065f46; }
+.disabled\:cursor-not-allowed:disabled { cursor: not-allowed; }
+.disabled\:opacity-60:disabled { opacity: 0.6; }
+.focus\:outline-none:focus { outline: none; }
+.focus-visible\:ring-4:focus-visible { box-shadow: 0 0 0 4px rgba(6, 95, 70, 0.35); }
+.focus-visible\:ring-emerald-200:focus-visible { box-shadow: 0 0 0 4px rgba(167, 243, 208, 0.6); }
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+.sm\:flex-row { flex-direction: column; }
+.md\:grid-cols-2 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+.md\:py-10 { padding-top: 2.5rem; padding-bottom: 2.5rem; }
+.md\:text-xl { font-size: 1.25rem; line-height: 1.75rem; }
+.md\:text-3xl { font-size: 1.875rem; line-height: 2.25rem; }
+.md\:text-4xl { font-size: 2.25rem; line-height: 2.5rem; }
+.md\:text-5xl { font-size: 3rem; line-height: 1; }
+@media (min-width: 640px) {
+  .sm\:flex-row { flex-direction: row; }
+}
+@media (min-width: 768px) {
+  .md\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .md\:py-10 { padding-top: 2.5rem; padding-bottom: 2.5rem; }
+  .md\:text-xl { font-size: 1.25rem; line-height: 1.75rem; }
+  .md\:text-3xl { font-size: 1.875rem; line-height: 2.25rem; }
+  .md\:text-4xl { font-size: 2.25rem; line-height: 2.5rem; }
+  .md\:text-5xl { font-size: 3rem; line-height: 1; }
+}


### PR DESCRIPTION
## Summary
- remove the Tailwind CDN runtime and load a static utility stylesheet instead
- add handcrafted CSS utilities that mirror the classes used by the quiz so legacy Android browsers can render the layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68deaf21abd0832eaea8c1bb577528b0