### PR TITLE
Add memorization study mode

### DIFF
--- a/src/components/GameMenu.js
+++ b/src/components/GameMenu.js
@@ -46,6 +46,7 @@ export default function GameMenu({
   onInterfaceLanguageChange,
   onStartClassicGame = () => {},
   onStartEndlessGame = () => {},
+  onStartMemorizationMode = () => {},
   isPostGame = false,
   score = 0,
   isMobile = false,
@@ -74,8 +75,10 @@ export default function GameMenu({
 
   const classicLabel = texts.classicModeButton || texts.startGame || 'Start Game';
   const endlessLabel = texts.endlessModeButton || 'Endless Mode';
+  const memorizationLabel = texts.memorizationModeButton || 'Memorization';
   const classicDescription = texts.classicModeDescription;
   const endlessDescription = texts.endlessModeDescription;
+  const memorizationDescription = texts.memorizationModeDescription;
   const unavailableLabel = texts.classicModeUnavailableButton || 'Unavailable';
 
   const [hoveredMode, setHoveredMode] = useState(null);
@@ -145,7 +148,13 @@ export default function GameMenu({
               onClick: onStartEndlessGame,
               className: 'px-6 py-3 font-semibold transition-colors hover:opacity-80',
               style: { backgroundColor: '#163B3A', color: '#C29C27', border: '4px solid #C29C27' }
-            }, endlessLabel)
+            }, endlessLabel),
+            createElement('button', {
+              key: 'memorization-button',
+              onClick: onStartMemorizationMode,
+              className: 'px-6 py-3 font-semibold transition-colors hover:opacity-80',
+              style: { backgroundColor: '#163B3A', color: '#C29C27', border: '4px solid #C29C27' }
+            }, texts.startMemorization || memorizationLabel)
           ])
         ])
       ])
@@ -327,6 +336,69 @@ export default function GameMenu({
                 opacity: hoveredMode === 'endless' ? 0.9 : 1
               }
             }, texts.startGame || 'Start'))
+          ].filter(Boolean))
+        ]),
+        createElement('div', {
+          key: 'memorization-card',
+          className: 'flex-1 relative transition-all cursor-pointer',
+          style: {
+            maxWidth: '520px',
+            transform: hoveredMode === 'memorization' ? 'translateY(-4px)' : 'translateY(0)',
+            transition: 'transform 0.3s ease'
+          },
+          onMouseEnter: () => setHoveredMode('memorization'),
+          onMouseLeave: () => setHoveredMode(null),
+          onClick: onStartMemorizationMode
+        }, [
+          createElement('div', {
+            key: 'memorization-border-outer',
+            className: 'absolute inset-0',
+            style: { border: '6px solid #C29C27' }
+          }),
+          createElement('div', {
+            key: 'memorization-border-inner',
+            className: 'absolute',
+            style: {
+              top: '16px',
+              left: '16px',
+              right: '16px',
+              bottom: '16px',
+              border: '2px solid #C29C27',
+              opacity: 0.6
+            }
+          }),
+          createElement('div', {
+            key: 'memorization-content',
+            className: 'relative p-8 flex flex-col text-center gap-4',
+            style: { minHeight: '240px' }
+          }, [
+            createElement('h2', {
+              key: 'memorization-title',
+              className: 'text-2xl font-bold',
+              style: { color: '#C29C27' }
+            }, memorizationLabel),
+            memorizationDescription && createElement('p', {
+              key: 'memorization-description',
+              className: 'text-base leading-relaxed',
+              style: { color: '#C29C27', opacity: 0.85 }
+            }, memorizationDescription),
+            createElement('div', {
+              key: 'memorization-button-wrapper',
+              className: 'mt-auto'
+            }, createElement('button', {
+              key: 'memorization-action',
+              onClick: event => {
+                event.stopPropagation();
+                onStartMemorizationMode();
+              },
+              className: 'w-full px-8 py-3 font-semibold transition-all',
+              style: {
+                backgroundColor: '#C29C27',
+                color: '#163B3A',
+                border: '3px solid #C29C27',
+                opacity: hoveredMode === 'memorization' ? 0.9 : 1
+              }
+            }, texts.startMemorization || memorizationLabel))
           ].filter(Boolean))
         ])
       ])

--- a/src/components/MemorizationScreen.js
+++ b/src/components/MemorizationScreen.js
@@ -1,0 +1,293 @@
+import { getPlantParameters } from '../data/plantParameters.js';
+import { defaultLang } from '../i18n/uiTexts.js';
+import useSecureImageSource from '../hooks/useSecureImageSource.js';
+
+const ACCENT_COLOR = '#C29C27';
+
+function getLocalizedValue(value, language) {
+  if (!value) {
+    return null;
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'object') {
+    if (value[language]) {
+      return value[language];
+    }
+    if (value[defaultLang]) {
+      return value[defaultLang];
+    }
+    const firstValue = Object.values(value).find(Boolean);
+    return typeof firstValue === 'string' ? firstValue : null;
+  }
+  return null;
+}
+
+function PlantImage({ plant, isMobile }) {
+  const ReactGlobal = globalThis.React;
+  if (!ReactGlobal) {
+    throw new Error('React global was not found. Make sure the React bundle is loaded before rendering PlantImage.');
+  }
+
+  const { createElement, useMemo } = ReactGlobal;
+  const imageSrc = plant && typeof plant.image === 'string' ? plant.image : null;
+  const { secureSrc, status } = useSecureImageSource(imageSrc);
+
+  const containerStyle = useMemo(() => ({
+    position: 'relative',
+    width: '100%',
+    paddingBottom: isMobile ? '66%' : '100%',
+    backgroundColor: '#0E2625',
+    border: isMobile ? '3px solid ' + ACCENT_COLOR : `6px solid ${ACCENT_COLOR}`,
+    overflow: 'hidden'
+  }), [isMobile]);
+
+  if (!imageSrc) {
+    return null;
+  }
+
+  if (status === 'error') {
+    return createElement('div', {
+      className: 'w-full flex items-center justify-center text-center p-6',
+      style: { ...containerStyle, padding: '24px', border: `2px dashed ${ACCENT_COLOR}` }
+    }, 'Изображение недоступно');
+  }
+
+  if (status !== 'ready' || !secureSrc) {
+    return createElement('div', {
+      className: 'w-full flex items-center justify-center',
+      style: containerStyle
+    }, createElement('span', { className: 'sr-only' }, 'Загрузка изображения'));
+  }
+
+  return createElement('div', {
+    className: 'relative w-full h-0',
+    style: containerStyle
+  }, createElement('img', {
+    src: secureSrc,
+    alt: plant.names?.[defaultLang] || `Plant ${plant.id}`,
+    style: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: '100%',
+      height: '100%',
+      objectFit: 'cover'
+    },
+    draggable: false,
+    onContextMenu: event => {
+      if (event && typeof event.preventDefault === 'function') {
+        event.preventDefault();
+      }
+    }
+  }));
+}
+
+export default function MemorizationScreen({
+  texts,
+  plantLanguage,
+  interfaceLanguage,
+  onPlantLanguageChange = () => {},
+  onNextPlant = () => {},
+  onReturnToMenu = () => {},
+  plant = null,
+  isMobile = false
+}) {
+  const ReactGlobal = globalThis.React;
+  if (!ReactGlobal) {
+    throw new Error('React global was not found. Make sure the React bundle is loaded before rendering MemorizationScreen.');
+  }
+
+  const { createElement, useMemo } = ReactGlobal;
+
+  const heading = texts.memorizationModeHeading || texts.memorizationModeButton || 'Memorization';
+  const instruction = texts.memorizationInstruction || '';
+  const unknownLabel = texts.memorizationUnknown || '—';
+  const nextButtonLabel = texts.memorizationNextButton || 'Next plant';
+  const backButtonLabel = texts.backToMenu || 'Back to Menu';
+
+  const availablePlantLanguages = useMemo(() => Array.from(new Set([
+    interfaceLanguage,
+    'sci'
+  ].filter(Boolean))), [interfaceLanguage]);
+
+  const plantName = plant && plant.names
+    ? (plant.names[plantLanguage] || plant.names[defaultLang] || plant.names.ru || Object.values(plant.names)[0])
+    : '';
+  const scientificName = plant && plant.names ? plant.names.sci : '';
+  const parameters = useMemo(() => {
+    if (!plant) {
+      return [];
+    }
+
+    const data = getPlantParameters(plant.id);
+    const items = [
+      {
+        key: 'family',
+        label: texts.memorizationFamilyLabel || 'Family',
+        value: getLocalizedValue(data?.family, interfaceLanguage)
+      },
+      {
+        key: 'lifeCycle',
+        label: texts.memorizationLifeCycleLabel || 'Life cycle',
+        value: getLocalizedValue(data?.lifeCycle, interfaceLanguage)
+      },
+      {
+        key: 'hardinessZone',
+        label: texts.memorizationHardinessLabel || 'Hardiness zone',
+        value: data?.hardinessZone || null
+      },
+      {
+        key: 'light',
+        label: texts.memorizationLightLabel || 'Light requirements',
+        value: getLocalizedValue(data?.light, interfaceLanguage)
+      },
+      {
+        key: 'toxicity',
+        label: texts.memorizationToxicityLabel || 'Toxicity',
+        value: getLocalizedValue(data?.toxicity, interfaceLanguage)
+      }
+    ];
+
+    return items.map(item => ({
+      ...item,
+      value: item.value || unknownLabel
+    }));
+  }, [plant, interfaceLanguage, texts, unknownLabel]);
+
+  if (!plant) {
+    return createElement('div', {
+      className: 'min-h-screen flex flex-col items-center justify-center text-center gap-6',
+      style: { backgroundColor: '#163B3A', color: ACCENT_COLOR, padding: '24px' }
+    }, [
+      createElement('p', {
+        key: 'no-plant',
+        className: 'text-xl font-semibold'
+      }, texts.memorizationNoPlant || 'Нет данных для отображения.'),
+      createElement('button', {
+        key: 'back-button',
+        onClick: onReturnToMenu,
+        className: 'px-6 py-3 font-semibold transition-all',
+        style: {
+          backgroundColor: ACCENT_COLOR,
+          color: '#163B3A',
+          border: `3px solid ${ACCENT_COLOR}`
+        }
+      }, backButtonLabel)
+    ]);
+  }
+
+  const layoutClass = isMobile
+    ? 'flex flex-col gap-6'
+    : 'grid grid-cols-2 gap-10 items-start';
+
+  return createElement('div', {
+    className: 'min-h-screen w-full flex flex-col items-center',
+    style: {
+      backgroundColor: '#163B3A',
+      color: ACCENT_COLOR,
+      padding: isMobile ? '16px' : '32px'
+    }
+  }, [
+    createElement('div', {
+      key: 'content',
+      className: `w-full ${layoutClass}`,
+      style: {
+        maxWidth: '1100px'
+      }
+    }, [
+      createElement('div', {
+        key: 'image-section',
+        className: 'w-full'
+      }, [
+        createElement('h1', {
+          key: 'heading',
+          className: isMobile ? 'text-3xl font-semibold mb-4 text-center' : 'text-4xl font-semibold mb-6',
+          style: { color: ACCENT_COLOR }
+        }, heading),
+        createElement(PlantImage, { plant, isMobile })
+      ]),
+      createElement('div', {
+        key: 'info-section',
+        className: 'w-full flex flex-col gap-5'
+      }, [
+        createElement('div', {
+          key: 'name-block',
+          className: 'flex flex-col gap-2'
+        }, [
+          createElement('div', {
+            key: 'language-switcher',
+            className: 'flex gap-2 flex-wrap'
+          }, availablePlantLanguages.map(lang => createElement('button', {
+            key: `lang-${lang}`,
+            onClick: () => onPlantLanguageChange(lang),
+            className: 'px-3 py-1 text-sm font-bold uppercase transition-all',
+            style: {
+              backgroundColor: plantLanguage === lang ? ACCENT_COLOR : 'transparent',
+              color: plantLanguage === lang ? '#163B3A' : ACCENT_COLOR,
+              border: `2px solid ${ACCENT_COLOR}`
+            }
+          }, lang === 'sci' ? 'Sci' : lang.toUpperCase()))),
+          createElement('h2', {
+            key: 'plant-name',
+            className: isMobile ? 'text-2xl font-bold' : 'text-3xl font-bold',
+            style: { color: ACCENT_COLOR }
+          }, plantName),
+          scientificName && createElement('span', {
+            key: 'scientific-name',
+            className: 'italic text-lg',
+            style: { color: ACCENT_COLOR, opacity: 0.8 }
+          }, scientificName)
+        ].filter(Boolean)),
+        instruction && createElement('p', {
+          key: 'instruction',
+          className: 'text-base',
+          style: { color: ACCENT_COLOR, opacity: 0.85 }
+        }, instruction),
+        createElement('div', {
+          key: 'parameters',
+          className: 'flex flex-col gap-3'
+        }, parameters.map(param => createElement('div', {
+          key: param.key,
+          className: 'flex flex-col gap-1'
+        }, [
+          createElement('span', {
+            key: `${param.key}-label`,
+            className: 'text-sm uppercase tracking-wide',
+            style: { opacity: 0.75 }
+          }, param.label),
+          createElement('span', {
+            key: `${param.key}-value`,
+            className: 'text-lg font-medium'
+          }, param.value)
+        ]))),
+        createElement('div', {
+          key: 'buttons',
+          className: isMobile ? 'flex flex-col gap-3 mt-4' : 'flex gap-4 mt-auto'
+        }, [
+          createElement('button', {
+            key: 'next-button',
+            onClick: onNextPlant,
+            className: 'px-6 py-3 font-semibold transition-all',
+            style: {
+              backgroundColor: ACCENT_COLOR,
+              color: '#163B3A',
+              border: `3px solid ${ACCENT_COLOR}`
+            }
+          }, nextButtonLabel),
+          createElement('button', {
+            key: 'back-button',
+            onClick: onReturnToMenu,
+            className: 'px-6 py-3 font-semibold transition-all',
+            style: {
+              backgroundColor: 'transparent',
+              color: ACCENT_COLOR,
+              border: `3px solid ${ACCENT_COLOR}`
+            }
+          }, backButtonLabel)
+        ])
+      ])
+    ])
+  ]);
+}

--- a/src/components/PlantQuizGame.js
+++ b/src/components/PlantQuizGame.js
@@ -2,6 +2,7 @@ import useGameLogic from '../hooks/useGameLogic.js';
 import GameScreen from './GameScreen.js';
 import ResultScreen from './ResultScreen.js';
 import GameMenu from './GameMenu.js';
+import MemorizationScreen from './MemorizationScreen.js';
 import { allQuestions } from '../data/questions.js';
 import { DataLoadingError } from '../utils/errorHandling.js';
 
@@ -27,10 +28,24 @@ export default function PlantQuizGame() {
       onInterfaceLanguageChange: game.changeInterfaceLanguage,
       onStartClassicGame: game.startClassicGame,
       onStartEndlessGame: game.startEndlessGame,
+      onStartMemorizationMode: game.startMemorizationMode,
       isPostGame: game.roundPhase === 'gameComplete',
       score: game.score,
       isMobile: game.isMobile,
       isClassicModeUnavailable: game.isClassicModeUnavailable
+    });
+  }
+
+  if (game.roundPhase === 'memorization') {
+    return createElement(MemorizationScreen, {
+      texts: game.texts,
+      plantLanguage: game.plantLanguage,
+      interfaceLanguage: game.interfaceLanguage,
+      onPlantLanguageChange: game.changePlantLanguage,
+      onNextPlant: game.showNextMemorizationPlant,
+      onReturnToMenu: game.returnToMenu,
+      plant: game.memorizationPlant,
+      isMobile: game.isMobile
     });
   }
 

--- a/src/data/plantParameters.js
+++ b/src/data/plantParameters.js
@@ -1,0 +1,64 @@
+const createLocalized = (ru, en, nl) => Object.freeze({ ru, en, nl });
+
+export const plantParametersById = Object.freeze({
+  1: Object.freeze({
+    family: createLocalized('Asteraceae', 'Asteraceae', 'Asteraceae'),
+    lifeCycle: createLocalized('Многолетник', 'Perennial', 'Meerjarig'),
+    hardinessZone: '9-11',
+    light: createLocalized('Полное солнце (6+ часов)', 'Full sun (6+ hours)', 'Volle zon (6+ uur)'),
+    toxicity: createLocalized('Нетоксично для людей и животных', 'Non-toxic to people and pets', 'Niet giftig voor mensen en dieren')
+  }),
+  3: Object.freeze({
+    family: createLocalized('Amaryllidaceae', 'Amaryllidaceae', 'Amaryllidaceae'),
+    lifeCycle: createLocalized('Многолетник', 'Perennial', 'Meerjarig'),
+    hardinessZone: '7-10',
+    light: createLocalized('Солнце — от 6 часов', 'Full sun (6+ hours)', 'Volle zon (6+ uur)'),
+    toxicity: createLocalized('Токсичен для людей и животных', 'Toxic to people and pets', 'Giftig voor mensen en dieren')
+  }),
+  5: Object.freeze({
+    family: createLocalized('Theaceae', 'Theaceae', 'Theaceae'),
+    lifeCycle: createLocalized('Многолетник', 'Perennial', 'Meerjarig'),
+    hardinessZone: '7-9',
+    light: createLocalized('Яркий рассеянный свет или полутень', 'Bright filtered light or partial shade', 'Helder gefilterd licht of halfschaduw'),
+    toxicity: createLocalized('Нетоксично для людей и животных', 'Non-toxic to people and pets', 'Niet giftig voor mensen en dieren')
+  }),
+  13: Object.freeze({
+    family: createLocalized('Amaryllidaceae', 'Amaryllidaceae', 'Amaryllidaceae'),
+    lifeCycle: createLocalized('Многолетник', 'Perennial', 'Meerjarig'),
+    hardinessZone: '4-9',
+    light: createLocalized('Полное солнце (6+ часов)', 'Full sun (6+ hours)', 'Volle zon (6+ uur)'),
+    toxicity: createLocalized('Токсично для домашних животных при проглатывании', 'Toxic to pets if ingested', 'Giftig voor huisdieren bij inname')
+  }),
+  21: Object.freeze({
+    family: createLocalized('Ericaceae', 'Ericaceae', 'Ericaceae'),
+    lifeCycle: createLocalized('Многолетник', 'Perennial', 'Meerjarig'),
+    hardinessZone: '4-8',
+    light: createLocalized('Рассеянный свет, полутень', 'Dappled light or partial shade', 'Gefilterd licht of halfschaduw'),
+    toxicity: createLocalized('Сильно токсично для людей и животных', 'Highly toxic to people and pets', 'Sterk giftig voor mensen en dieren')
+  }),
+  31: Object.freeze({
+    family: createLocalized('Rosaceae', 'Rosaceae', 'Rosaceae'),
+    lifeCycle: createLocalized('Многолетник', 'Perennial', 'Meerjarig'),
+    hardinessZone: '3-9',
+    light: createLocalized('Полное солнце (6+ часов)', 'Full sun (6+ hours)', 'Volle zon (6+ uur)'),
+    toxicity: createLocalized('Нетоксично, но осторожно с шипами', 'Non-toxic, but watch the thorns', 'Niet giftig, maar pas op voor de doornen')
+  }),
+  68: Object.freeze({
+    family: createLocalized('Lamiaceae', 'Lamiaceae', 'Lamiaceae'),
+    lifeCycle: createLocalized('Многолетник', 'Perennial', 'Meerjarig'),
+    hardinessZone: '5-9',
+    light: createLocalized('Полное солнце (6+ часов)', 'Full sun (6+ hours)', 'Volle zon (6+ uur)'),
+    toxicity: createLocalized('Легко токсична для животных при проглатывании', 'Mildly toxic to pets if ingested', 'Licht giftig voor huisdieren bij inname')
+  }),
+  88: Object.freeze({
+    family: createLocalized('Hydrangeaceae', 'Hydrangeaceae', 'Hydrangeaceae'),
+    lifeCycle: createLocalized('Многолетний кустарник', 'Perennial shrub', 'Meerjarige struik'),
+    hardinessZone: '5-9',
+    light: createLocalized('Утреннее солнце и дневная полутень', 'Morning sun with afternoon shade', 'Ochtendezon en middaghalfschaduw'),
+    toxicity: createLocalized('Токсична при проглатывании', 'Toxic if ingested', 'Giftig bij inname')
+  })
+});
+
+export function getPlantParameters(id) {
+  return plantParametersById[id] || null;
+}

--- a/src/gameConfig.js
+++ b/src/gameConfig.js
@@ -9,7 +9,8 @@ export const INTERFACE_LANGUAGES = ['ru', 'en', 'nl'];
 
 export const GAME_MODES = Object.freeze({
   CLASSIC: 'classic',
-  ENDLESS: 'endless'
+  ENDLESS: 'endless',
+  MEMORIZATION: 'memorization'
 });
 
 export const DEFAULT_LANGUAGE_STORAGE_KEY = 'gtp-default-language';

--- a/src/i18n/uiTexts.js
+++ b/src/i18n/uiTexts.js
@@ -31,7 +31,20 @@ export const uiTexts = {
     endlessSuccessTitle: "Поздравляем! Вы прошли бесконечный режим!",
     endlessFailureTitle: "Слишком много ошибок! Попробуйте ещё раз",
     endlessRetry: "Повторить",
-    backToMenu: "Вернуться в меню"
+    backToMenu: "Вернуться в меню",
+    memorizationModeButton: "Заучивание",
+    memorizationModeDescription: "Изучайте растения с фото, названиями и важными параметрами.",
+    startMemorization: "Начать заучивание",
+    memorizationModeHeading: "Режим заучивания",
+    memorizationInstruction: "Запоминайте название и характеристики, затем переходите к следующему растению.",
+    memorizationFamilyLabel: "Семейство",
+    memorizationLifeCycleLabel: "Продолжительность жизни",
+    memorizationHardinessLabel: "Зона морозостойкости",
+    memorizationLightLabel: "Освещение",
+    memorizationToxicityLabel: "Токсичность",
+    memorizationNextButton: "Следующее растение",
+    memorizationUnknown: "Нет данных",
+    memorizationNoPlant: "Нет данных для отображения."
   },
   en: {
     question: "What plant is this?",
@@ -65,7 +78,20 @@ export const uiTexts = {
     endlessSuccessTitle: "Congratulations! You completed Endless Mode!",
     endlessFailureTitle: "Too many mistakes! Try again",
     endlessRetry: "Retry",
-    backToMenu: "Back to Menu"
+    backToMenu: "Back to Menu",
+    memorizationModeButton: "Study Mode",
+    memorizationModeDescription: "Explore plants with photos, names, and key facts.",
+    startMemorization: "Start studying",
+    memorizationModeHeading: "Study Mode",
+    memorizationInstruction: "Review the details and move to the next plant when you are ready.",
+    memorizationFamilyLabel: "Family",
+    memorizationLifeCycleLabel: "Life cycle",
+    memorizationHardinessLabel: "Hardiness zone",
+    memorizationLightLabel: "Light requirements",
+    memorizationToxicityLabel: "Toxicity",
+    memorizationNextButton: "Next plant",
+    memorizationUnknown: "Not specified",
+    memorizationNoPlant: "No plant data available."
   },
   nl: {
     question: "Wat is deze plant?",
@@ -99,7 +125,20 @@ export const uiTexts = {
     endlessSuccessTitle: "Gefeliciteerd! Je hebt de eindeloze modus voltooid!",
     endlessFailureTitle: "Te veel fouten! Probeer het opnieuw",
     endlessRetry: "Opnieuw",
-    backToMenu: "Terug naar menu"
+    backToMenu: "Terug naar menu",
+    memorizationModeButton: "Studiemodus",
+    memorizationModeDescription: "Leer planten kennen met foto's, namen en belangrijke kenmerken.",
+    startMemorization: "Start studeren",
+    memorizationModeHeading: "Studiemodus",
+    memorizationInstruction: "Bekijk de details en ga verder naar de volgende plant wanneer je klaar bent.",
+    memorizationFamilyLabel: "Familie",
+    memorizationLifeCycleLabel: "Levensduur",
+    memorizationHardinessLabel: "Winterhardheidszone",
+    memorizationLightLabel: "Lichtbehoefte",
+    memorizationToxicityLabel: "Giftigheid",
+    memorizationNextButton: "Volgende plant",
+    memorizationUnknown: "Niet gespecificeerd",
+    memorizationNoPlant: "Geen plantgegevens beschikbaar."
   }
 };
 


### PR DESCRIPTION
## Summary
- add a memorization study mode with a dedicated screen that shows plant names, images, and care parameters
- extend the game menu, game logic, and localization strings to support launching the new mode
- add structured plant parameter data to power the memorization details view

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dfa8df2174832e95c8cc935e3e3717