### PR TITLE
Recheck classic mode availability when returning to menu

### DIFF
--- a/src/hooks/useGameLogic.js
+++ b/src/hooks/useGameLogic.js
@@ -251,6 +251,14 @@ export default function useGameLogic() {
   }, []);
 
   useEffect(() => {
+    if (roundPhase !== 'menu') {
+      return;
+    }
+
+    setClassicModeUnavailable(isClassicModeDisabled());
+  }, [roundPhase, setClassicModeUnavailable]);
+
+  useEffect(() => {
     if (roundPhase !== 'playing') {
       return;
     }


### PR DESCRIPTION
## Summary
- re-check classic mode availability whenever the menu is shown so newly added questions can re-enable classic mode

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1657994a8832e9ac0aa63133860d9