### PR TITLE
Fix feedback panel border overlap

### DIFF
--- a/src/components/GameScreen.js
+++ b/src/components/GameScreen.js
@@ -179,6 +179,7 @@ function renderFeedbackPanel(ReactGlobal, type, texts, isMobile, themeAccentColo
       minHeight: isMobile ? '220px' : '260px',
       border: frameBorder,
       borderRadius: frameRadius,
+      boxSizing: 'border-box',
       backgroundColor: 'transparent',
       display: 'flex',
       alignItems: 'center',


### PR DESCRIPTION
## Summary
- ensure the feedback panel's inner frame respects the outer frame by using border-box sizing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e14ea23bcc832e99cccdbae25e69d4